### PR TITLE
Fix URL error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ share/python-wheels/
 *.egg
 MANIFES
 *.pt
+*.tmp

--- a/src/opensynth/datasets/datasets_utils.py
+++ b/src/opensynth/datasets/datasets_utils.py
@@ -45,7 +45,7 @@ def download_data(url: str, filename: Path, unzip: bool = False):
         if filename.exists():
             os.remove(filename)
         logging.info(f"Downloading data from: {url}")
-        wget.download(url, filename)
+        wget.download(url, str(filename))
     else:
         logging.info("Skipping download")
 


### PR DESCRIPTION
WGET can only take in string, cannot take in a PosixPath. This PR converts PosixPath to string to fix the bug.