### PR TITLE
Make implementation of Faraday agnostic to data modules and features

### DIFF
--- a/src/opensynth/data_modules/lcl_data_module.py
+++ b/src/opensynth/data_modules/lcl_data_module.py
@@ -3,7 +3,7 @@
 
 import ast
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,11 @@ from torch.utils.data import DataLoader, Dataset
 RANDOM_STATE = 0
 g = torch.Generator()
 g.manual_seed(RANDOM_STATE)
+
+
+class TrainingData(TypedDict):
+    kwh: torch.tensor
+    features: dict[str, torch.tensor]
 
 
 class LCLData(Dataset):
@@ -95,10 +100,11 @@ class LCLData(Dataset):
 
     def __getitem__(self, idx):
         standardised_kwh = self.standardise(self.kwh[idx])
-        mth = self.month[idx]
-        dow = self.dayofweek[idx]
-
-        return standardised_kwh, mth, dow
+        features: dict[str, torch.tensor] = {
+            "month": self.month[idx],
+            "dayofweek": self.dayofweek[idx],
+        }
+        return TrainingData(kwh=standardised_kwh, features=features)
 
 
 class LCLDataModule(pl.LightningDataModule):

--- a/src/opensynth/data_modules/lcl_data_module.py
+++ b/src/opensynth/data_modules/lcl_data_module.py
@@ -23,7 +23,13 @@ class TrainingData(TypedDict):
 
 class LCLData(Dataset):
     """
-    Low CarbonLondon Dataset
+    Low CarbonLondon Dataset. The dataset should return
+    TrainingData(TypedDict) which contains:
+    - kwh: kWh data
+    - features: Dictionary of features
+
+    To use Faraday on custom datasets, your data module
+    should also return data in the same format.
     """
 
     def __init__(

--- a/src/opensynth/data_modules/lcl_data_module.py
+++ b/src/opensynth/data_modules/lcl_data_module.py
@@ -17,8 +17,8 @@ g.manual_seed(RANDOM_STATE)
 
 
 class TrainingData(TypedDict):
-    kwh: torch.tensor
-    features: dict[str, torch.tensor]
+    kwh: torch.Tensor
+    features: dict[str, torch.Tensor]
 
 
 class LCLData(Dataset):
@@ -71,27 +71,27 @@ class LCLData(Dataset):
         self.month = self.df["month"]
         self.dayofweek = self.df["dayofweek"]
 
-    def standardise(self, x: torch.tensor) -> torch.tensor:
+    def standardise(self, x: torch.Tensor) -> torch.Tensor:
         """
         Standardise kWh with mean 0 and std 1
 
         Args:
-            x (torch.tensor): Input kWh
+            x (torch.Tensor): Input kWh
 
         Returns:
-            torch.tensor: Standardised kWh
+            torch.Tensor: Standardised kWh
         """
         return (x - self.feature_mean) / self.feature_std
 
-    def reconstruct(self, xhat: torch.tensor) -> torch.tensor:
+    def reconstruct(self, xhat: torch.Tensor) -> torch.Tensor:
         """
         Reconstruct kWh from standardised values
 
         Args:
-            xhat (torch.tensor): standardised kWh
+            xhat (torch.Tensor): standardised kWh
 
         Returns:
-            torch.tensor: reconstructed kWh
+            torch.Tensor: reconstructed kWh
         """
         return (xhat * self.feature_std) + self.feature_mean
 
@@ -100,7 +100,7 @@ class LCLData(Dataset):
 
     def __getitem__(self, idx):
         standardised_kwh = self.standardise(self.kwh[idx])
-        features: dict[str, torch.tensor] = {
+        features: dict[str, torch.Tensor] = {
             "month": self.month[idx],
             "dayofweek": self.dayofweek[idx],
         }
@@ -165,5 +165,5 @@ class LCLDataModule(pl.LightningDataModule):
             generator=g,
         )
 
-    def reconstruct_kwh(self, xhat: torch.tensor) -> torch.tensor:
+    def reconstruct_kwh(self, xhat: torch.Tensor) -> torch.Tensor:
         return self.dataset.reconstruct(xhat)

--- a/src/opensynth/evaluation/privacy/generate_attack_data.py
+++ b/src/opensynth/evaluation/privacy/generate_attack_data.py
@@ -9,7 +9,7 @@ from opensynth.models.faraday import FaradayModel
 
 def generate_synthetic_samples(
     model: FaradayModel, dm: LCLDataModule, n_samples: int
-) -> torch.tensor:
+) -> torch.Tensor:
     """
     Generate synthetic samples from model.
     TODO: Add support for non-Faraday models in the future by
@@ -21,7 +21,7 @@ def generate_synthetic_samples(
         n_samples (int): Number of synhetic samples to generate.
 
     Returns:
-        torch.tensor: Synthetic samples.
+        torch.Tensor: Synthetic samples.
     """
     synthetic_samples = model.sample_gmm(n_samples)
     synthetic_kwh = synthetic_samples[0]
@@ -32,7 +32,7 @@ def generate_synthetic_samples(
 
 def draw_real_data(
     dm: LCLDataModule, n_samples: int, outliers: bool = False
-) -> torch.tensor:
+) -> torch.Tensor:
     """
     Draw real samples from data module
 
@@ -43,7 +43,7 @@ def draw_real_data(
         training data. Defaults to False.
 
     Returns:
-        torch.tensor: Real training samples.
+        torch.Tensor: Real training samples.
     """
     if outliers:
         samples = next(iter(dm.outlier_dataloader()))

--- a/src/opensynth/evaluation/privacy/membership_inference_attack.py
+++ b/src/opensynth/evaluation/privacy/membership_inference_attack.py
@@ -35,7 +35,7 @@ class MembershipInferenceAttackSamples:
     outlier_unseen_diff_samples: torch.Tensor
 
 
-def _create_unseen_outliers(df: pd.DataFrame, mean: float) -> torch.tensor:
+def _create_unseen_outliers(df: pd.DataFrame, mean: float) -> torch.Tensor:
     """
     Creates unseen outliers. Calls unpon the method
     opensynth.datasets.low_carbon_london.preprocess_lcl.create_outliers.
@@ -47,7 +47,7 @@ def _create_unseen_outliers(df: pd.DataFrame, mean: float) -> torch.tensor:
         mean (float): Mean value for gaussian and gamma distribution.
 
     Returns:
-        torch.tensor: Generated unseen outliers.
+        torch.Tensor: Generated unseen outliers.
     """
     outliers = create_outliers(df, mean)
     return torch.from_numpy(np.array(outliers["kwh"].values.tolist()))

--- a/src/opensynth/evaluation/privacy/reconstruction_attack.py
+++ b/src/opensynth/evaluation/privacy/reconstruction_attack.py
@@ -61,17 +61,17 @@ def create_attack_dataset(
 
 
 def _calculate_pairwise_euclidean(
-    vec1: torch.tensor, vec2: torch.tensor
-) -> torch.tensor:
+    vec1: torch.Tensor, vec2: torch.Tensor
+) -> torch.Tensor:
     """
         Calculates pairwise euclidean distance. Creates a matrix of
         Size(Vec1) X Size(Vec2)
     Args:
-        vec1 (torch.tensor): Vector 1
-        vec2 (torch.tensor): Vector 2
+        vec1 (torch.Tensor): Vector 1
+        vec2 (torch.Tensor): Vector 2
 
     Returns:
-        torch.tensor: Pairwise euclidean distance matrix
+        torch.Tensor: Pairwise euclidean distance matrix
     """
     logger.info("Calculating pairwise euclidean distance..")
     euc_pairwise = torch.cdist(vec1, vec2)
@@ -79,14 +79,14 @@ def _calculate_pairwise_euclidean(
 
 
 def _convert_wide_to_long(
-    matrix: torch.tensor, metric_name: str
+    matrix: torch.Tensor, metric_name: str
 ) -> pd.DataFrame:
     """
     Converts euclidean matrix (wide table) to long table of
     pairwise distances
 
     Args:
-        matrix (torch.tensor): Pairwise euclidean distance matrix
+        matrix (torch.Tensor): Pairwise euclidean distance matrix
         metric_name (str): Metric name
 
     Returns:
@@ -108,12 +108,12 @@ def _convert_wide_to_long(
     return df_out
 
 
-def _calculate_vector_norm(data: torch.tensor) -> pd.DataFrame:
+def _calculate_vector_norm(data: torch.Tensor) -> pd.DataFrame:
     """
     Calculate norm of outlier vector
 
     Args:
-        data (torch.tensor): Input data
+        data (torch.Tensor): Input data
 
     Returns:
         pd.DataFrame: A long dataframe consisting of the seen outlier
@@ -127,14 +127,14 @@ def _calculate_vector_norm(data: torch.tensor) -> pd.DataFrame:
 
 
 def calculate_distance_norm(
-    real: torch.tensor, fake: torch.tensor, group_min: bool = True
+    real: torch.Tensor, fake: torch.Tensor, group_min: bool = True
 ) -> pd.DataFrame:
     """
     Calculates distance norms between generated data and seen outliers.
 
     Args:
-        real (torch.tensor): Seen outlier
-        fake (torch.tensor): Generated data
+        real (torch.Tensor): Seen outlier
+        fake (torch.Tensor): Generated data
         group_min (bool, optional): Group pairwise distances to
         return only the nearest neighbour. Defaults to True. If
         False, returns all pairwise distances.

--- a/src/opensynth/models/faraday/losses.py
+++ b/src/opensynth/models/faraday/losses.py
@@ -7,16 +7,16 @@ import torch
 import torch.nn.functional as F
 
 
-def MMDLoss(y: torch.tensor, x: torch.tensor) -> torch.tensor:
+def MMDLoss(y: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     """
     Calculate MMD Loss
 
     Args:
-        y (torch.tensor): Tensor Y
-        x (torch.tensor): Tensor X
+        y (torch.Tensor): Tensor Y
+        x (torch.Tensor): Tensor X
 
     Returns:
-        torch.tensor: MMD Distances between Tensor Y and X
+        torch.Tensor: MMD Distances between Tensor Y and X
     """
 
     xx, yy, zz = torch.mm(x, x.t()), torch.mm(y, y.t()), torch.mm(x, y.t())
@@ -46,18 +46,18 @@ def MMDLoss(y: torch.tensor, x: torch.tensor) -> torch.tensor:
 
 
 def quantile_loss(
-    y_pred: torch.tensor, y_real: torch.tensor, quantile: float
-) -> torch.tensor:
+    y_pred: torch.Tensor, y_real: torch.Tensor, quantile: float
+) -> torch.Tensor:
     """
     Calculate quantile loss
     #TODO: Test this function
     Args:
-        y_pred (torch.tensor): Predicted quantile
-        y_real (torch.tensor): Actual quantile
+        y_pred (torch.Tensor): Predicted quantile
+        y_real (torch.Tensor): Actual quantile
         quantile (float): Quantile value
 
     Returns:
-        torch.tensor: Quantile loss
+        torch.Tensor: Quantile loss
     """
     return torch.mean(
         torch.max(
@@ -67,15 +67,15 @@ def quantile_loss(
 
 
 def calculate_training_loss(
-    x_hat: torch.tensor,
-    x: torch.tensor,
+    x_hat: torch.Tensor,
+    x: torch.Tensor,
     mse_weight: float,
     quantile_upper_weight: float,
     quantile_lower_weight: float,
     quantile_median_weight: float,
     lower_quantile: float,
     upper_quantile: float,
-) -> Tuple[torch.tensor, torch.tensor, torch.tensor, torch.tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Calculate training losses for Faraday.
     Losses are a combined total of:
@@ -85,8 +85,8 @@ def calculate_training_loss(
     4) lower quantile loss * lower quantile weight
     5) median quantile loss * median quantile weight
     Args:
-        x_hat (torch.tensor): Generated tensor
-        x (torch.tensor): Real tensor
+        x_hat (torch.Tensor): Generated tensor
+        x (torch.Tensor): Real tensor
         mse_weight (float): MSE Weight
         quantile_upper_weight (float): Upper quantile weight
         quantile_lower_weight (float): Lower quantile weight
@@ -95,7 +95,7 @@ def calculate_training_loss(
         upper_quantile (float): Upper quantile value
 
     Returns:
-        Tuple[torch.tensor, torch.tensor, torch.tensor, torch.tensor]:
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         Total loss, MMD loss, MSE loss, Quantile loss
     """
     mmd_loss = MMDLoss(x_hat, x)

--- a/src/opensynth/models/faraday/model.py
+++ b/src/opensynth/models/faraday/model.py
@@ -326,6 +326,8 @@ class FaradayModel:
         - Faraday Model only supports integer-encoded labels.
         - If you wish to have float labels, you should subclass FaradayModel
         and implement your own `sample_gmm` method.
+        - Faraday Model also expects data module to return a
+        TrainingData object.
 
         Args:
             vae_module (FaradayVAE): Trained VAE component

--- a/src/opensynth/models/faraday/model.py
+++ b/src/opensynth/models/faraday/model.py
@@ -321,7 +321,11 @@ class FaradayModel:
         tol: float = 1e-3,
     ):
         """
-        Faraday Model
+        Faraday Model. Note:
+
+        - Faraday Model only supports integer-encoded labels.
+        - If you wish to have float labels, you should subclass FaradayModel
+        and implement your own `sample_gmm` method.
 
         Args:
             vae_module (FaradayVAE): Trained VAE component
@@ -418,7 +422,9 @@ class FaradayModel:
     @staticmethod
     def get_index(feature_list: list[str], current_index: int) -> int:
         """
-        Get the index of each label
+        Get the index of each label, so that we can store the
+        correct column as the correct label in the gmm_labels
+        dictionary which the VAE needs in order to decode.
 
         Args:
             feature_list (list[str]): List of features
@@ -478,7 +484,10 @@ class FaradayModel:
         # Parse labels and profiles
         gmm_kwh = gmm_samples[:, : self.vae_module.latent_dim]
         gmm_labels: dict[str, torch.Tensor] = {}
+
         # Abstract the labels and round numerical values to integers
+        # Order of features needs to be preserved so VAE can decode
+        # it correctly, and is handled by `get_index` method.
         for i, feature in enumerate(self.vae_module.feature_list):
             index = self.get_index(self.vae_module.feature_list, i)
             gmm_labels[feature] = np.round(

--- a/tests/models/faraday/test_faraday_model.py
+++ b/tests/models/faraday/test_faraday_model.py
@@ -6,15 +6,15 @@ from opensynth.models.faraday import FaradayModel, FaradayVAE
 
 
 @pytest.fixture
-def kwh_tensor() -> torch.tensor:
+def kwh_tensor() -> torch.Tensor:
     kwh = np.random.rand(100, 48)
     return torch.from_numpy(kwh).float()
 
 
 @pytest.fixture
-def feature_dict() -> dict[str, torch.tensor]:
+def feature_dict() -> dict[str, torch.Tensor]:
     feature_list = ["feature_1", "feature_2"]
-    output_dict: dict[str, torch.tensor] = {}
+    output_dict: dict[str, torch.Tensor] = {}
     for feature in feature_list:
         # numpy randint high is exclusive!
         random_tensor = np.random.randint(low=0, high=6, size=100)
@@ -51,7 +51,7 @@ def test_faraday_model_get_mask(feature_dict):
     expected_mask = feature_1_mask & feature_2_mask
 
     # Compare expected mask vs results from create_mask
-    test_dict: dict[str, torch.tensor] = {
+    test_dict: dict[str, torch.Tensor] = {
         "feature_1": torch.from_numpy(test_labels),
         "feature_2": torch.from_numpy(test_labels),
     }
@@ -61,7 +61,7 @@ def test_faraday_model_get_mask(feature_dict):
     assert (got_mask == expected_mask).all()
 
 
-def test_get_index(feature_dict: dict[str, torch.tensor]):
+def test_get_index(feature_dict: dict[str, torch.Tensor]):
     feature_list = list(feature_dict.keys())
     for feature, value in enumerate(feature_list):
         if feature == "feature_1":

--- a/tests/models/faraday/test_faraday_model.py
+++ b/tests/models/faraday/test_faraday_model.py
@@ -65,8 +65,10 @@ def test_get_index(feature_dict: dict[str, torch.Tensor]):
     feature_list = list(feature_dict.keys())
     for feature_index, feature_value in enumerate(feature_list):
         if feature_value == "feature_1":
-            # First feature in feature_dict should have index = -2
+            # There are two items in the list, so first item
+            # should have index = -2 [last X column]
             assert FaradayModel.get_index(feature_list, feature_index) == -2
         elif feature_value == "feature_2":
-            # Second feature in feature_dict should have index = -1
+            # There are two items in the list, so second item
+            # should have index = -1 [last column]
             assert FaradayModel.get_index(feature_list, feature_index) == -1

--- a/tests/models/faraday/test_faraday_model.py
+++ b/tests/models/faraday/test_faraday_model.py
@@ -63,10 +63,10 @@ def test_faraday_model_get_mask(feature_dict):
 
 def test_get_index(feature_dict: dict[str, torch.Tensor]):
     feature_list = list(feature_dict.keys())
-    for feature, value in enumerate(feature_list):
-        if feature == "feature_1":
-            # First feature in feature_dict should have index = 1
-            assert FaradayModel.get_index(feature_list, value) == 1
-        elif feature == "feature_2":
-            # Second feature in feature_dict should have index = 2
-            assert FaradayModel.get_index(feature_list, value) == 2
+    for feature_index, feature_value in enumerate(feature_list):
+        if feature_value == "feature_1":
+            # First feature in feature_dict should have index = -2
+            assert FaradayModel.get_index(feature_list, feature_index) == -2
+        elif feature_value == "feature_2":
+            # Second feature in feature_dict should have index = -1
+            assert FaradayModel.get_index(feature_list, feature_index) == -1

--- a/tests/models/faraday/test_faraday_model.py
+++ b/tests/models/faraday/test_faraday_model.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+import torch
+
+from opensynth.models.faraday import FaradayModel, FaradayVAE
+
+
+@pytest.fixture
+def kwh_tensor() -> torch.tensor:
+    kwh = np.random.rand(100, 48)
+    return torch.from_numpy(kwh).float()
+
+
+@pytest.fixture
+def feature_dict() -> dict[str, torch.tensor]:
+    feature_list = ["feature_1", "feature_2"]
+    output_dict: dict[str, torch.tensor] = {}
+    for feature in feature_list:
+        # numpy randint high is exclusive!
+        random_tensor = np.random.randint(low=0, high=6, size=100)
+        output_dict[feature] = torch.from_numpy(random_tensor)
+    return output_dict
+
+
+def test_faraday_vae_reshape_data(kwh_tensor, feature_dict):
+    reshaped_data = FaradayVAE.reshape_data(kwh_tensor, feature_dict)
+    expected_dim1 = len(kwh_tensor)
+    expected_dim2 = kwh_tensor.shape[1] + len(feature_dict)
+    assert reshaped_data.shape == (expected_dim1, expected_dim2)
+
+
+def test_faraday_model_feature_range(feature_dict):
+    got_range = FaradayModel.get_feature_range(feature_dict)
+    assert got_range == {
+        "feature_1": {"min": 0, "max": 5},
+        "feature_2": {"min": 0, "max": 5},
+    }
+
+
+def test_faraday_model_get_mask(feature_dict):
+
+    test_labels = np.array([100] * 100)
+
+    # Calculate the mask explicitly
+    feature_1_mask = (
+        test_labels <= feature_dict["feature_1"].detach().numpy().max()
+    )
+    feature_2_mask = (
+        test_labels <= feature_dict["feature_2"].detach().numpy().max()
+    )
+    expected_mask = feature_1_mask & feature_2_mask
+
+    # Compare expected mask vs results from create_mask
+    test_dict: dict[str, torch.tensor] = {
+        "feature_1": torch.from_numpy(test_labels),
+        "feature_2": torch.from_numpy(test_labels),
+    }
+    test_range = FaradayModel.get_feature_range(feature_dict)
+    got_mask = FaradayModel.create_mask(test_dict, test_range)
+
+    assert (got_mask == expected_mask).all()
+
+
+def test_get_index(feature_dict: dict[str, torch.tensor]):
+    feature_list = list(feature_dict.keys())
+    for feature, value in enumerate(feature_list):
+        if feature == "feature_1":
+            # First feature in feature_dict should have index = 1
+            assert FaradayModel.get_index(feature_list, value) == 1
+        elif feature == "feature_2":
+            # Second feature in feature_dict should have index = 2
+            assert FaradayModel.get_index(feature_list, value) == 2


### PR DESCRIPTION
Current Faraday source code is tightly coupled with the Data Module and cannot support an arbitrary data module with arbitrary features. For instance, model features were hard coded in FaradayVAE's training loop.

This PR decouples Faraday source codes and data modules:
- List of features are defined in the data modules which Faraday source could will infer from
- Faraday VAE and GMM modules can arbitrary train on datasets with any prescribed features, instead of being hard coded to "month" and "dayofweek" as it is currently
- This will require data modules to return: two items 1) the kWh and 2) a dictionary of feature tensors. As long as the data modules satisfy these 2 criteria, Faraday's source could will work accordingly

~TODO:~
- Write tests ✅ 
- Test code with Non-LCL dataset ✅ 