### PR TITLE
Implement sample weights for faraday

### DIFF
--- a/src/opensynth/models/faraday/losses.py
+++ b/src/opensynth/models/faraday/losses.py
@@ -86,8 +86,10 @@ def quantile_loss(
     quantile_loss = torch.max(
         quantile * (y_real - y_pred), (1 - quantile) * (y_pred - y_real)
     )
+
     if sample_weights is not None:
         quantile_loss = quantile_loss * sample_weights
+        return torch.sum(quantile_loss) / torch.sum(sample_weights)
 
     return torch.mean(quantile_loss)
 
@@ -111,8 +113,11 @@ def mse_loss(
         _type_: _description_
     """
     squared_loss = F.mse_loss(y_pred, y_real, reduction="none")
+
     if sample_weights is not None:
         squared_loss = squared_loss * sample_weights
+        return torch.sum(squared_loss) / torch.sum(sample_weights)
+
     return torch.mean(squared_loss)
 
 

--- a/src/opensynth/models/faraday/losses.py
+++ b/src/opensynth/models/faraday/losses.py
@@ -7,7 +7,24 @@ import torch
 import torch.nn.functional as F
 
 
-def MMDLoss(y: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+def _expand_samples(x: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+    """
+    Expand the repeat in the tensor based on the sample weights
+    e.g. if x: [1,2,3] and weights: [1,2,3], the output will be [1,2,2,3,3,3]
+
+    Args:
+        x (torch.Tensor): Input tensor
+        weights (torch.Tensor): Sample weight
+
+    Returns:
+        torch.Tensor: Repeated tensor by sample weight
+    """
+    return torch.cat([x[i].repeat(weights[i], 1) for i in range(len(weights))])
+
+
+def mmd_loss(
+    y: torch.Tensor, x: torch.Tensor, sample_weights: torch.Tensor = None
+) -> torch.Tensor:
     """
     Calculate MMD Loss
 
@@ -18,6 +35,10 @@ def MMDLoss(y: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     Returns:
         torch.Tensor: MMD Distances between Tensor Y and X
     """
+    # Expand the weights array based on number of samples
+    if sample_weights:
+        x = _expand_samples(x, sample_weights)
+        y = _expand_samples(y, sample_weights)
 
     xx, yy, zz = torch.mm(x, x.t()), torch.mm(y, y.t()), torch.mm(x, y.t())
     rx = xx.diag().unsqueeze(0).expand_as(xx)
@@ -46,11 +67,13 @@ def MMDLoss(y: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
 
 
 def quantile_loss(
-    y_pred: torch.Tensor, y_real: torch.Tensor, quantile: float
+    y_pred: torch.Tensor,
+    y_real: torch.Tensor,
+    quantile: float,
+    sample_weights: torch.Tensor = None,
 ) -> torch.Tensor:
     """
     Calculate quantile loss
-    #TODO: Test this function
     Args:
         y_pred (torch.Tensor): Predicted quantile
         y_real (torch.Tensor): Actual quantile
@@ -59,11 +82,38 @@ def quantile_loss(
     Returns:
         torch.Tensor: Quantile loss
     """
-    return torch.mean(
-        torch.max(
-            quantile * (y_real - y_pred), (1 - quantile) * (y_pred - y_real)
-        )
+
+    quantile_loss = torch.max(
+        quantile * (y_real - y_pred), (1 - quantile) * (y_pred - y_real)
     )
+    if sample_weights is not None:
+        quantile_loss = quantile_loss * sample_weights
+
+    return torch.mean(quantile_loss)
+
+
+def mse_loss(
+    y_pred: torch.Tensor,
+    y_real: torch.Tensor,
+    sample_weights: torch.Tensor = None,
+):
+    """
+    Calculate MSE loss. If sample weights are provided, sample losses are
+    multiplied by the sample weight before averaging.
+
+    Args:
+        y_pred (torch.Tensor): Prediction
+        y_real (torch.Tensor): Actual
+        sample_weights (torch.Tensor, optional): Sample Weights.
+        Defaults to None.
+
+    Returns:
+        _type_: _description_
+    """
+    squared_loss = F.mse_loss(y_pred, y_real, reduction="none")
+    if sample_weights is not None:
+        squared_loss = squared_loss * sample_weights
+    return torch.mean(squared_loss)
 
 
 def calculate_training_loss(
@@ -75,6 +125,7 @@ def calculate_training_loss(
     quantile_median_weight: float,
     lower_quantile: float,
     upper_quantile: float,
+    sample_weights: torch.Tensor = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Calculate training losses for Faraday.
@@ -98,21 +149,23 @@ def calculate_training_loss(
         Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         Total loss, MMD loss, MSE loss, Quantile loss
     """
-    mmd_loss = MMDLoss(x_hat, x)
-    mse_loss = F.mse_loss(x_hat, x) * mse_weight
+    mmd_loss_ = mmd_loss(x_hat, x, sample_weights=sample_weights)
+    mse_loss_ = mse_loss(x_hat, x, sample_weights=sample_weights)
     quantile_upper_loss = (
-        quantile_loss(x_hat, x, upper_quantile) * quantile_upper_weight
+        quantile_loss(x_hat, x, upper_quantile, sample_weights)
+        * quantile_upper_weight
     )
     quantile_lower_loss = (
-        quantile_loss(x_hat, x, lower_quantile) * quantile_lower_weight
+        quantile_loss(x_hat, x, lower_quantile, sample_weights)
+        * quantile_lower_weight
     )
     quantile_median_loss = (
-        quantile_loss(x_hat, x, 0.5) * quantile_median_weight
+        quantile_loss(x_hat, x, 0.5, sample_weights) * quantile_median_weight
     )
     quantile_losses = (
         quantile_upper_loss + quantile_lower_loss + quantile_median_loss
     )
 
-    total_loss = mmd_loss + mse_loss + quantile_losses
+    total_loss = mmd_loss_ + mse_loss_ + quantile_losses
 
-    return total_loss, mmd_loss, mse_loss, quantile_losses
+    return total_loss, mmd_loss_, mse_loss_, quantile_losses

--- a/tests/models/faraday/test_faraday_losses.py
+++ b/tests/models/faraday/test_faraday_losses.py
@@ -10,13 +10,38 @@ class TestFaradayLosses:
     mmd_tol = 0.001
     norm_dist_1 = Normal(0, 1)
     norm_dist_2 = Normal(25, 96)
-    tensor1 = torch.tensor([1, 2, 3, 4, 5])
-    tensor2 = torch.tensor([0, 0, 0, 0, 0])
+    tensor1 = torch.tensor([1, 2, 3, 4, 5]).float()
+    tensor2 = torch.tensor([0, 0, 0, 0, 0]).float()
+    weights = torch.tensor([1, 1, 3, 1, 5])
+
+    def test_expand_samples_1d_tensor(self):
+        tensor1_expanded = losses._expand_samples(self.tensor1, self.weights)
+        expected_tensor = torch.tensor(
+            [1, 2, 3, 3, 3, 4, 5, 5, 5, 5, 5]
+        ).float()
+        assert torch.equal(
+            tensor1_expanded.squeeze(),
+            expected_tensor.squeeze(),
+        )
+
+    def test_expand_samples_2d_tensor(self):
+        tensor1 = self.tensor1.reshape(len(self.tensor1), 1)
+        tensor1_expanded = losses._expand_samples(tensor1, self.weights)
+        expected_tensor_flat = torch.tensor(
+            [1, 2, 3, 3, 3, 4, 5, 5, 5, 5, 5]
+        ).float()
+        expected_tensor = expected_tensor_flat.reshape(
+            len(expected_tensor_flat), 1
+        )
+        assert torch.equal(
+            tensor1_expanded,
+            expected_tensor,
+        )
 
     @pytest.mark.parametrize(
         "d1,d2,tol",
         [
-            # Exact tensor should return quantile loss of 0
+            # Exact tensor should return MMD loss of 0
             pytest.param(norm_dist_1, norm_dist_1, mmd_tol),
             pytest.param(
                 norm_dist_1,
@@ -29,7 +54,7 @@ class TestFaradayLosses:
     def test_mmd_loss(self, d1, d2, tol):
         sample_1 = d1.sample([5000, 2])
         sample_2 = d2.sample([5000, 2])
-        got_mmd_loss = losses.MMDLoss(sample_1, sample_2)
+        got_mmd_loss = losses.mmd_loss(sample_1, sample_2)
         assert torch.round(got_mmd_loss, decimals=3) <= tol
 
     @pytest.mark.parametrize(
@@ -45,3 +70,29 @@ class TestFaradayLosses:
     def test_quantile_loss(self, t1, t2, quantile, expected_value):
         got_loss = losses.quantile_loss(t1, t2, quantile)
         assert torch.round(got_loss, decimals=2) == expected_value
+
+    @pytest.mark.parametrize(
+        "t1,t2,quantile,expected_value",
+        [
+            # Exact tensor should return quantile loss of 0
+            pytest.param(tensor1, tensor1, 0.5, 0),
+            pytest.param(tensor1, tensor2, 0.5, 4.1),
+        ],
+    )
+    def test_quantile_loss_with_weights(
+        self, t1, t2, quantile, expected_value
+    ):
+        got_loss = losses.quantile_loss(t1, t2, quantile, self.weights)
+        assert torch.round(got_loss, decimals=2) == expected_value
+
+    @pytest.mark.parametrize(
+        "t1,t2,expected_value",
+        [
+            # Exact tensor should return quantile loss of 0
+            pytest.param(tensor1, tensor1, 0),
+            pytest.param(tensor1, tensor2, 34.6),
+        ],
+    )
+    def test_mse_loss(self, t1, t2, expected_value):
+        got_loss = losses.mse_loss(t1, t2, self.weights)
+        assert got_loss == expected_value


### PR DESCRIPTION
Calculates weighted losses by:

1. For MMD loss, we have to expand the tensors based on the sample weights as MSE weights operate on a distribution level
2. For MSE loss and quantile loss, we:
    - Calculate sample-wise losses
    - Instead of using the standard reduction method (mean), we calculate the weighted mean
    - Do this by multiplying sample-wise losses by sample weights, then taking the sum of losses and divide by the sum of weights
 
Edge cases and logic are tested in `TestFaradayLosses`.