### PR TITLE
More efficient implementation of weighted MMD loss.

### DIFF
--- a/src/opensynth/models/faraday/losses.py
+++ b/src/opensynth/models/faraday/losses.py
@@ -19,7 +19,8 @@ def _expand_samples(x: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
     Returns:
         torch.Tensor: Repeated tensor by sample weight
     """
-    return torch.cat([x[i].repeat(weights[i], 1) for i in range(len(weights))])
+    weights = weights.squeeze().long()
+    return torch.repeat_interleave(x, weights, dim=0)
 
 
 def mmd_loss(

--- a/tests/models/faraday/test_faraday_losses.py
+++ b/tests/models/faraday/test_faraday_losses.py
@@ -57,6 +57,32 @@ class TestFaradayLosses:
         got_mmd_loss = losses.mmd_loss(sample_1, sample_2)
         assert torch.round(got_mmd_loss, decimals=3) <= tol
 
+    def test_mmd_loss_weighted_and_expanded_same_values(self):
+
+        N = 1000
+        sample_1 = self.norm_dist_1.sample([N, 2])
+        sample_2 = self.norm_dist_2.sample([N, 2])
+        weights = torch.randint(low=1, high=3, size=(N, 1))
+        assert weights.sum() > N
+
+        got_mmd_loss = losses.mmd_loss(sample_1, sample_2, weights)
+        got_mmd_loss = torch.round(got_mmd_loss, decimals=3)
+
+        # Expanded samples
+        sample_1_expanded = losses._expand_samples(sample_1, weights)
+        sample_2_expanded = losses._expand_samples(sample_2, weights)
+
+        # Check that expanded samples are larger than original samples!
+        assert len(sample_1_expanded) == weights.sum()
+        assert len(sample_2_expanded) == weights.sum()
+
+        expected_mmd_loss = losses.mmd_loss(
+            sample_1_expanded, sample_2_expanded
+        )
+        expected_mmd_loss = torch.round(expected_mmd_loss, decimals=3)
+
+        assert got_mmd_loss == expected_mmd_loss
+
     @pytest.mark.parametrize(
         "t1,t2,quantile,expected_value",
         [


### PR DESCRIPTION
Previous implementation of MMD loss is very inefficient as it involves expanding the batch size based weights. This results in needless computation. This is a problem for MMD because MMD compute cost is N^2.

**Previous implementation**
```python

xx = torch.tensor([[1,2],[1,3]], dtype=torch.float32)
yy =torch.tensor([[1,3],[1,4]], dtype=torch.float32)

weights = torch.tensor([1,3])

xx_expanded = torch.tensor([
        [1., 2.],
        [1., 3.],
        [1., 3.],
        [1., 3.]
]) # vice versa for yy

# Then we proceed on to calculate MMD losses. This involves unnecessary matrix multiplication on a much bigger dimension (4X4 as opposed to 3X3).
```

**New implementation**
```python

# Instead of expanding the batch size based on weights, we proceed on to calculate MMD as per usual.
# However before the reduction step, we apply a 'hack'

xx = torch.tensor([[1,2],[1,3]], dtype=torch.float32)
yy =torch.tensor([[1,3],[1,4]], dtype=torch.float32)

weights = torch.tensor([1,3])

xx_expanded = torch.tensor([
        [1., 2.],
        [1., 3.],
        [1., 3.],
        [1., 3.]
]) # vice versa for yy

# MMD Matrix based on xx_expanded and yy_expanded:
tensor([
        [ 0.2324, -0.2324, -0.2324, -0.2324],
        [ 0.6485,  0.2324,  0.2324,  0.2324],
        [ 0.6485,  0.2324,  0.2324,  0.2324],
        [ 0.6485,  0.2324,  0.2324,  0.2324]])

# MMD Matrix based on xx and yy (not expanded)
tensor([
        [ 0.2324, -0.2324],
        [ 0.6485,  0.2324]
])
```

As you can see, the tensor return with xx and yy (non expanded) is just a condensed version of the expanded MMD arrays. To make the calculation more efficient, we can:

1. Multiply the MMD matrix by the weights (element wise) to get:
```python
tensor([[ 0.2324, -0.6972],
        [ 0.6485,  0.6972]])

# This results in a matrix that has the same row-wise sum as the 'expanded' version, as we're multiplying each element in the matrix by the weights (occurrence). However we also need to repeat the calculations on the other axes.
```

2. Repeat the MMD matrix using torch's torch.repeat_interleave() to get:
```python
tensor([[ 0.2324, -0.6972],
        [ 0.6485,  0.6972],
        [ 0.6485,  0.6972],
        [ 0.6485,  0.6972]])

# This is a more efficient implementation than the previous implementation using list comprehension. The resulting matrix has the same row-wise sum for all elements.
```

3. Then to calculate the 'mean MMD loss per batch', sum the matrix from 2️⃣  and divide by `weights.sum() **2` as there would be weights.sum() ** 2 number of elements in the 'expanded' matrix.

Pytest implemented to compare sample-weighted MMD losses from expanded version (original implementation) vs this more efficient implementation. 

Tested on OE's dataset with batch size of 5000 X 51 (13 abels + 48 kWh):
- Original implementation ~ 0.2 iterations/s 
- New implementation ~ 2.0 iterations/s
- No sample weights ~ 2.7 iteration/s

New implementation is still slower than no sample weights, but significantly faster than the previous implementation