### PR TITLE
bug-fix/ fix keyerror bug

### DIFF
--- a/.github/workflows/check_licences.yaml
+++ b/.github/workflows/check_licences.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Scan code base for GPL/ GNU licenses with Scancode-toolkit
         id: gpl_scan
         run: |
-          docker run -v $PWD/:/project scancode-toolkit -clpeui -n 1 --ignore /project/scancode-toolkit/* --ignore /project/.github/* --ignore /project/scripts/* --json-pp /project/scan_results.json /project --verbose
+          docker run -v $PWD/:/project scancode-toolkit -clpeui -n 1 --ignore /project/scancode-toolkit/* --ignore /project/.github/* --ignore /project/scripts/* --ignore /project/notebooks/* --json-pp /project/scan_results.json /project --verbose
           ./scripts/check_gpl.sh
 
       - name: Output file locations of GPL licenses

--- a/scripts/check_gpl.sh
+++ b/scripts/check_gpl.sh
@@ -7,7 +7,7 @@ JSON_FILE="scan_results.json"
 GPL_LICENSES=("GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-only" "GPL-3.0-or-later")
 
 # Directory to exclude from the scan
-EXCLUDED_DIR="notebooks"
+EXCLUDED_DIR="project/notebooks"
 
 # Check if jq is installed
 if ! command -v jq &> /dev/null; then

--- a/scripts/check_gpl.sh
+++ b/scripts/check_gpl.sh
@@ -6,6 +6,9 @@ JSON_FILE="scan_results.json"
 # List of GPL licenses to search for
 GPL_LICENSES=("GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-only" "GPL-3.0-or-later")
 
+# Directory to exclude from the scan
+EXCLUDED_DIR="notebooks"
+
 # Check if jq is installed
 if ! command -v jq &> /dev/null; then
     echo "jq is not installed. Please install jq to run this script."
@@ -16,6 +19,13 @@ fi
 check_for_gpl_licenses() {
     local file=$1
     local found=0
+
+    # Exclude files in the "notebooks" directory
+    if [[ "$file" == *"$EXCLUDED_DIR"* ]]; then
+        echo "Skipping file in excluded directory: $file"
+        return
+    fi
+
     for license in "${GPL_LICENSES[@]}"; do
         # Find all matching detections for the GPL licenses
         local matches=$(jq -c ".license_detections[] | select(.license_expression_spdx == \"$license\")" "$file")

--- a/src/opensynth/evaluation/privacy/generate_attack_data.py
+++ b/src/opensynth/evaluation/privacy/generate_attack_data.py
@@ -24,7 +24,7 @@ def generate_synthetic_samples(
         torch.Tensor: Synthetic samples.
     """
     synthetic_samples = model.sample_gmm(n_samples)
-    synthetic_kwh = synthetic_samples[0]
+    synthetic_kwh = synthetic_samples["kwh"]
     synthetic_kwh = dm.reconstruct_kwh(synthetic_kwh)
     synthetic_kwh = torch.clip(synthetic_kwh, min=0)
     return synthetic_kwh
@@ -51,7 +51,7 @@ def draw_real_data(
         dm.batch_size = n_samples
         samples = next(iter(dm.train_dataloader()))
 
-    real_kwh = samples[0]
+    real_kwh = samples["kwh"]
     real_kwh = dm.reconstruct_kwh(real_kwh)
     real_kwh = torch.clip(real_kwh, min=0)
     return real_kwh

--- a/src/opensynth/evaluation/privacy/membership_inference_attack.py
+++ b/src/opensynth/evaluation/privacy/membership_inference_attack.py
@@ -80,6 +80,7 @@ def _create_attack_samples(
         dm_train (LCLDataModule): Train data module
         dm_holdout (LCLDataModule): Holdout data module
         n_samples (int, optional): Number of samples. Defaults to 20000.
+        mean_factor (int): Mean factor for outliers. Defaults to 20.
 
     Returns:
         MembershipInferenceAttackSamples: Attack samples
@@ -225,6 +226,7 @@ class MembershipInferenceDataModule(pl.LightningDataModule):
             dm_train (LCLDataModule): Train data module with outliers injected
             dm_holdout (LCLDataModule): Holdout data module
             batch_size (int): Batch size for MIA.
+            mean_factor (int): Mean factor for outliers. Defaults to 20.
         """
 
         super().__init__()


### PR DESCRIPTION
Previously sample_gmm returned a Tuple but it was updated to returning the TrainingData TypedDict. However we forgot to update the code for evaluation.

Also add notebooks to list of folders to ignore from license checks as when notebooks are converted into raw byte strings, it could sometimes have strings that resemble "GPL" that fools `scancode`'s logic. Furthermore notebooks are not part of the distributed software so it's safe to ignore notebooks from license checks.