### PR TITLE
Make sample weights optional for gmm

### DIFF
--- a/src/opensynth/models/faraday/gaussian_mixture/fit_gmm.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/fit_gmm.py
@@ -74,8 +74,6 @@ def fit_gmm(
         GaussianMixtureLightningModule: GMM lightning module
         pl.Trainer: Pytorch Lightning Trainer for GMM
     """
-    # TODO: Figure out how to take in sample weights and
-    # pass it in to prepare_data_for_gmm
     start_time = time.time()
 
     # Initialize the GMM model
@@ -108,6 +106,7 @@ def fit_gmm(
         init_method=init_method,
         covariance_regularization=covariance_regularization,
         is_batch_training=is_batch_training,
+        train_sample_weights=train_sample_weights,
     )
 
     pl.Trainer(
@@ -126,6 +125,7 @@ def fit_gmm(
         is_batch_training=is_batch_training,
         covariance_regularization=covariance_regularization,
         convergence_tolerance=gmm_convergence_tolerance,
+        train_sample_weights=train_sample_weights,
     )
     trainer = pl.Trainer(
         max_epochs=gmm_max_epochs,

--- a/src/opensynth/models/faraday/gaussian_mixture/fit_gmm.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/fit_gmm.py
@@ -31,6 +31,7 @@ def fit_gmm(
     num_components: int,
     vae_module: FaradayVAE,
     num_features: int,
+    train_sample_weights: bool = False,
     gmm_max_epochs: int = 10000,
     gmm_convergence_tolerance: float = 1e-6,
     covariance_regularization: float = 1e-6,
@@ -48,6 +49,8 @@ def fit_gmm(
         vae_module (FaradayVAE): trained VAE model.
         num_features (int): number of features in latent space
             (size of latent space + number of non encoded features)
+        train_sample_weights (bool, optional): flag whether to train with
+            sample weights. Defaults to False.
         gmm_max_epochs (int, optional): maximum epochs to run GMM fitting.
             Defaults to 10000.
         gmm_convergence_tolerance (float, optional): convergence tolerance for
@@ -71,7 +74,8 @@ def fit_gmm(
         GaussianMixtureLightningModule: GMM lightning module
         pl.Trainer: Pytorch Lightning Trainer for GMM
     """
-
+    # TODO: Figure out how to take in sample weights and
+    # pass it in to prepare_data_for_gmm
     start_time = time.time()
 
     # Initialize the GMM model

--- a/src/opensynth/models/faraday/gaussian_mixture/gmm_lightning.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/gmm_lightning.py
@@ -43,6 +43,7 @@ class GaussianMixtureLightningModule(pl.LightningModule):
         convergence_tolerance: float = 1e-6,
         covariance_regularization: float = 1e-6,
         is_batch_training: bool = False,
+        train_sample_weights: bool = False,
     ):
         super().__init__()
         self.model = model
@@ -52,6 +53,7 @@ class GaussianMixtureLightningModule(pl.LightningModule):
         self.covariance_regularization = covariance_regularization
         self.is_batch_training = is_batch_training
         self.vae_module = vae_module
+        self.train_sample_weights = train_sample_weights
         self.save_hyperparameters(
             "num_components",
             "num_features",
@@ -111,7 +113,11 @@ class GaussianMixtureLightningModule(pl.LightningModule):
     def training_step(self, batch: torch.Tensor) -> None:
 
         # Encode the batch
-        encoded_batch = prepare_data_for_model(self.vae_module, batch)
+        encoded_batch = prepare_data_for_model(
+            self.vae_module,
+            batch,
+            train_sample_weights=self.train_sample_weights,
+        )
 
         if self._computes_responsibilities_on_live_model:
             log_responsibilities, log_probs = self.model.forward(encoded_batch)
@@ -172,7 +178,9 @@ class GaussianMixtureLightningModule(pl.LightningModule):
 
     def test_step(self, batch: torch.Tensor, _batch_idx: int) -> None:
         _, log_probs = self.model.forward(
-            prepare_data_for_model(self.vae_module, batch)
+            prepare_data_for_model(
+                self.vae_module, batch, self.train_sample_weights
+            )
         )
         self.metric_nll.update(-log_probs)
         self.log("nll", self.metric_nll)
@@ -181,7 +189,9 @@ class GaussianMixtureLightningModule(pl.LightningModule):
         self, batch: torch.Tensor, batch_idx: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
         log_responsibilities, log_probs = self.model.forward(
-            prepare_data_for_model(self.vae_module, batch)
+            prepare_data_for_model(
+                self.vae_module, batch, self.train_sample_weights
+            )
         )
         return log_responsibilities.exp(), -log_probs
 
@@ -231,6 +241,7 @@ class GaussianMixtureInitLightningModule(pl.LightningModule):
         init_method: str = "kmeans",
         covariance_regularization: float = 1e-6,
         is_batch_training: bool = True,
+        train_sample_weights: bool = False,
     ):
         """
         Args:
@@ -248,6 +259,7 @@ class GaussianMixtureInitLightningModule(pl.LightningModule):
         self.init_method = init_method
         self.is_batch_training = is_batch_training
         self.vae_module = vae_module
+        self.train_sample_weights = train_sample_weights
         self.save_hyperparameters("init_method")
 
         self.prior_aggregator = PriorAggregator(
@@ -291,7 +303,9 @@ class GaussianMixtureInitLightningModule(pl.LightningModule):
     def training_step(self, batch: torch.Tensor, batch_idx: int) -> None:
 
         # Encode the batch
-        encoded_batch = prepare_data_for_model(self.vae_module, batch)
+        encoded_batch = prepare_data_for_model(
+            self.vae_module, batch, self.train_sample_weights
+        )
 
         if self.init_method == "kmeans":
             # Just like for k-means, responsibilities are one-hot assignments

--- a/src/opensynth/models/faraday/gaussian_mixture/gmm_lightning.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/gmm_lightning.py
@@ -40,10 +40,10 @@ class GaussianMixtureLightningModule(pl.LightningModule):
         vae_module: FaradayVAE,
         num_components: int,
         num_features: int,
+        train_sample_weights: bool,
         convergence_tolerance: float = 1e-6,
         covariance_regularization: float = 1e-6,
         is_batch_training: bool = False,
-        train_sample_weights: bool = False,
     ):
         super().__init__()
         self.model = model
@@ -238,10 +238,10 @@ class GaussianMixtureInitLightningModule(pl.LightningModule):
         vae_module: FaradayVAE,
         num_components: int,
         num_features: int,
+        train_sample_weights: bool,
         init_method: str = "kmeans",
         covariance_regularization: float = 1e-6,
         is_batch_training: bool = True,
-        train_sample_weights: bool = False,
     ):
         """
         Args:

--- a/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
@@ -48,7 +48,7 @@ def expand_weights(data: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
 def prepare_data_for_model(
     vae_module: FaradayVAE,
     data: torch.Tensor,
-    train_sample_weights: bool = False,
+    train_sample_weights: bool,
 ) -> torch.Tensor:
     """Prepare data for the GMM by encoding it with the VAE.
      If sample weights are used, then expand the repeat based on the weights
@@ -57,7 +57,7 @@ def prepare_data_for_model(
     Args:
         data (torch.Tensor): data for GMM training.
         vae_module (FaradayVAE): VAE module used for encoding.
-        train_sample_weights (bool): flag whether to train with sample weights.
+        train_sample_weights: flag whether to train with sample weights.
         Defaults to false
     Returns:
         torch.Tensor: model inputs consisting of encoded consumption data and

--- a/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
@@ -46,7 +46,9 @@ def expand_weights(data: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
 
 
 def prepare_data_for_model(
-    vae_module: FaradayVAE, data: torch.Tensor
+    vae_module: FaradayVAE,
+    data: torch.Tensor,
+    train_sample_weights: bool = False,
 ) -> torch.Tensor:
     """Prepare data for the GMM by encoding it with the VAE.
      If sample weights are used, then expand the repeat based on the weights
@@ -55,12 +57,21 @@ def prepare_data_for_model(
     Args:
         data (torch.Tensor): data for GMM training.
         vae_module (FaradayVAE): VAE module used for encoding.
+        train_sample_weights (bool): flag whether to train with sample weights.
+        Defaults to false
     Returns:
         torch.Tensor: model inputs consisting of encoded consumption data and
         features.
     """
     model_input = encode_data_for_gmm(data, vae_module)
-    if "weights" in data:
-        model_input = expand_weights(model_input, data["weights"])
+
+    if train_sample_weights:
+        try:
+            model_input = expand_weights(model_input, data["weights"])
+        except KeyError:
+            raise KeyError(
+                f"train_sample_weights set to {train_sample_weights} but"
+                "weights not found in data."
+            )
 
     return model_input

--- a/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
+++ b/src/opensynth/models/faraday/gaussian_mixture/prepare_gmm_input.py
@@ -58,7 +58,6 @@ def prepare_data_for_model(
         data (torch.Tensor): data for GMM training.
         vae_module (FaradayVAE): VAE module used for encoding.
         train_sample_weights: flag whether to train with sample weights.
-        Defaults to false
     Returns:
         torch.Tensor: model inputs consisting of encoded consumption data and
         features.

--- a/src/opensynth/models/faraday/model.py
+++ b/src/opensynth/models/faraday/model.py
@@ -27,6 +27,7 @@ class FaradayModel:
         devices: int = 1,
         gmm_max_epochs: int = 1000,
         gmm_covariance_reg: float = 1e-6,
+        train_sample_weights: bool = False,
     ):
         """
         Faraday Model. Note:
@@ -55,6 +56,8 @@ class FaradayModel:
                 ensure that it is positive semi-definite. Higher values will
                 make the algorithm more robust to singular covariance matrices,
                 at the cost of higher regularization.
+            train_sample_weights (bool, optional): Train with sample weights.
+                Defaults to False.
         """
         self.n_components = n_components
         self.vae_module = vae_module
@@ -64,6 +67,7 @@ class FaradayModel:
         self.devices = devices
         self.gmm_max_epochs = gmm_max_epochs
         self.gmm_covariance_reg = gmm_covariance_reg
+        self.train_sample_weights = train_sample_weights
 
     @staticmethod
     def parse_samples(
@@ -234,6 +238,7 @@ class FaradayModel:
         gmm_module, _, _ = fit_gmm(
             data=dl,
             vae_module=self.vae_module,
+            train_sample_weights=self.train_sample_weights,
             num_components=self.n_components,
             num_features=self.vae_module.latent_dim
             + len(obtained_feature_list),

--- a/tests/models/faraday/gaussian_mixture/test_gmm_inputs.py
+++ b/tests/models/faraday/gaussian_mixture/test_gmm_inputs.py
@@ -24,16 +24,16 @@ class TestGMMDataPreparation:
 
     unweighted_batch = TrainingData(kwh=kwh, features=features)
 
-    def check_data_size(self):
+    def test_check_data_size(self):
 
-        model_input = prepare_data_for_model(self.vae_module, self.batch)
+        model_input = prepare_data_for_model(self.vae_module, self.batch, True)
 
         assert model_input.shape[0] == self.batch["weights"].sum()
         assert model_input.shape[1] == self.vae_module.latent_dim + len(
             self.batch["features"].keys()
         )
 
-    def check_weights(self):
+    def test_check_weights(self):
         # Check weights > 1 have been incorporated correctly
         # If sample weight = 3, expect 3 rows of the same data in final tensor
         # Expect these rows to be shuffled into random positions in the final

--- a/tests/models/faraday/gaussian_mixture/test_gmm_inputs.py
+++ b/tests/models/faraday/gaussian_mixture/test_gmm_inputs.py
@@ -85,7 +85,7 @@ class TestGMMDataPreparation:
 
     def test_no_weights(self):
         model_input = prepare_data_for_model(
-            self.vae_module, self.unweighted_batch
+            self.vae_module, self.unweighted_batch, False
         )
 
         assert model_input.size(0) == 100

--- a/tests/models/faraday/gaussian_mixture/test_gmm_lightning.py
+++ b/tests/models/faraday/gaussian_mixture/test_gmm_lightning.py
@@ -1,0 +1,57 @@
+import pytest
+
+from opensynth.models.faraday import FaradayVAE
+from opensynth.models.faraday.gaussian_mixture import GaussianMixtureModel
+from opensynth.models.faraday.gaussian_mixture.gmm_lightning import (
+    GaussianMixtureInitLightningModule,
+    GaussianMixtureLightningModule,
+)
+
+
+class TestGmmLightningSampleWeightInvocation:
+
+    vae_module = FaradayVAE(
+        class_dim=2, latent_dim=16, learning_rate=0.001, mse_weight=3
+    )
+
+    gmm_module = GaussianMixtureModel(2, 2)
+
+    def test_gmm_init_module_sample_weights_true(self):
+        init_module = GaussianMixtureInitLightningModule(
+            self.gmm_module,
+            self.vae_module,
+            num_components=2,
+            num_features=2,
+            train_sample_weights=True,
+        )
+        assert init_module
+
+    @pytest.mark.xfail(raises=TypeError, strict=True)
+    def test_gmm_init_module_sample_weights_missing(self):
+        init_module = GaussianMixtureInitLightningModule(
+            self.gmm_module,
+            self.vae_module,
+            num_components=2,
+            num_features=2,
+        )
+        assert init_module
+
+    def test_gmm_lightning_module_sample_weights_true(self):
+        gmm_module = GaussianMixtureLightningModule(
+            self.gmm_module,  # init_module.model,
+            self.vae_module,
+            num_components=2,
+            num_features=2,
+            train_sample_weights=True,
+        )
+        assert gmm_module
+
+    @pytest.mark.xfail(raises=TypeError, strict=True)
+    def test_gmm_lightning_module_sample_weights_missing(self):
+        gmm_module = GaussianMixtureLightningModule(
+            self.gmm_module,  # init_module.model,
+            self.vae_module,
+            num_components=2,
+            num_features=2,
+        )
+        assert gmm_module


### PR DESCRIPTION
Make fitting gmm with sample weights optional, defaulting to false. Sample weights may not always be used depending on use cases. This makes it optional and allows end user to control when to use or not use it.