### PR TITLE
Update data processing scripts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ litdata = "*"
 zstd = "*"
 einops = ">=0.7.0"
 ema-pytorch = "==0.4.5"
+pytest = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2f6e5c8770b33f1485158211d3f1492a67310d2ee0eaec4aa2cd077fac5084e0"
+            "sha256": "6a48d2583367bdda9d2e4dbb7cfbb0ea4a45f6e165fe986e18846ad6da3684a4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -522,6 +522,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
+        },
         "jinja2": {
             "hashes": [
                 "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
@@ -936,11 +944,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
-                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.2"
+            "version": "==25.0"
         },
         "pandas": {
             "hashes": [
@@ -1055,6 +1063,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==11.1.0"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
         "propcache": {
             "hashes": [
                 "sha256:02df07041e0820cacc8f739510078f2aadcfd3fc57eaeeb16d5ded85c872c89e",
@@ -1159,6 +1175,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.3.0"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.2"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1",
@@ -1166,6 +1190,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.2.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01",
+                "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.2"
         },
         "python-dateutil": {
             "hashes": [

--- a/app/app.py
+++ b/app/app.py
@@ -19,30 +19,136 @@ app = typer.Typer(context_settings=dict(max_content_width=800))
 
 
 @app.command()
-def get_lcl_data(
-    download: Annotated[
-        bool, typer.Option("--download", help="Downloads LCL data.")
-    ] = False,
-    split: Annotated[
-        bool,
-        typer.Option(
-            "--split", help="Splits LCL households into training/ holdout set"
-        ),
-    ] = False,
-    preprocess: Annotated[
-        bool,
-        typer.Option(
-            "--preprocess",
-            help="Preprocesses LCL data to create 48-half hour daily"
-            "load profiles",
-        ),
-    ] = False,
+def download_lcl_data(
+    data_dir: Annotated[
+        str, typer.Option("--loc", help="Downloads LCL data to <location>.")
+    ] = "./data"
 ):
     """
-    Download, split and preprocess the Low Carbon London dataset.
+    Download the Low Carbon London dataset.
     """
-    get_data.get_lcl_data(
-        download=download, split=split, preprocess=preprocess
+    get_data.get_lcl_data(data_dir)
+
+
+@app.command()
+def preprocess_data(
+    data_dir: Annotated[
+        str, typer.Option("--loc", help="Location of data directory.")
+    ] = "./data",
+    csv_data_path: Annotated[
+        str,
+        typer.Option(
+            "--csv_path",
+            help="Path to dataset CSV file containing, relative to data_dir.",
+        ),
+    ] = "raw/CC_LCL-FullData.csv",
+    sample_fraction: Annotated[
+        float,
+        typer.Option(
+            "--sample_fraction",
+            help="Fraction of households to sample from the dataset.",
+        ),
+    ] = 0.75,
+    time_resolution: Annotated[
+        str,
+        typer.Option(
+            "--time_resolution",
+            help='Time resolution of the data, either "half_hourly" or \
+                "hourly".',
+        ),
+    ] = "half_hourly",
+    feature_cols: Annotated[
+        list[str],
+        typer.Option(
+            "--feature_cols",
+            help="List of feature columns to include in the dataset.",
+        ),
+    ] = ["stdorToU"],
+    id_col: Annotated[
+        str,
+        typer.Option(
+            "--id_col",
+            help="Name of the household ID column.",
+        ),
+    ] = "LCLid",
+    kwh_col: Annotated[
+        str,
+        typer.Option(
+            "--kwh_col",
+            help="Name of the kWh column.",
+        ),
+    ] = "KWH/hh (per half hour) ",
+    datetime_col: Annotated[
+        str,
+        typer.Option(
+            "--datetime_col",
+            help="Name of the datetime column.",
+        ),
+    ] = "DateTime",
+    utc: Annotated[
+        bool,
+        typer.Option(
+            "--utc",
+            help="Whether the datetime is in UTC.",
+        ),
+    ] = False,
+    datetime_format: Annotated[
+        str | None,
+        typer.Option(
+            "--datetime_format",
+            help="Format of the datetime column, if not standard.",
+        ),
+    ] = None,
+    historical_start: Annotated[
+        str,
+        typer.Option(
+            "--historical_start",
+            help="Start date for historical data (YYYY-MM-DD).",
+        ),
+    ] = "2012-01-01",
+    historical_end: Annotated[
+        str,
+        typer.Option(
+            "--historical_end",
+            help="End date for historical data (YYYY-MM-DD).",
+        ),
+    ] = "2013-12-31",
+    future_start: Annotated[
+        str,
+        typer.Option(
+            "--future_start",
+            help="Start date for future data (YYYY-MM-DD).",
+        ),
+    ] = "2014-01-01",
+    future_end: Annotated[
+        str,
+        typer.Option(
+            "--future_end",
+            help="End date for future data (YYYY-MM-DD).",
+        ),
+    ] = "2014-12-31",
+):
+    """
+    Split and preprocess your dataset.
+    Default args are suitable for the LCL dataset. Modify as needed for other
+    datasets.
+    """
+
+    get_data.split_preprocess_data(
+        data_dir,
+        csv_data_path,
+        sample_fraction,
+        time_resolution,
+        feature_cols,
+        id_col,
+        kwh_col,
+        datetime_col,
+        utc,
+        datetime_format,
+        historical_start,
+        historical_end,
+        future_start,
+        future_end,
     )
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -127,6 +127,14 @@ def preprocess_data(
             help="End date for future data (YYYY-MM-DD).",
         ),
     ] = "2014-12-31",
+    drop_nulls: Annotated[
+        bool,
+        typer.Option(
+            "--drop_nulls",
+            help="Whether to drop rows with NaN kwh values. If False, will \
+            replace NaN kwh values with 0.0",
+        ),
+    ] = True,
 ):
     """
     Split and preprocess your dataset.
@@ -149,6 +157,7 @@ def preprocess_data(
         historical_end,
         future_start,
         future_end,
+        drop_nulls,
     )
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -46,7 +46,9 @@ def preprocess_data(
         float,
         typer.Option(
             "--sample_fraction",
-            help="Fraction of households to sample from the dataset.",
+            help="Fraction of households to include in the training set. \
+                Remaining fraction assigned to the holdout set. \
+                Value between 0 and 1.",
         ),
     ] = 0.75,
     time_resolution: Annotated[

--- a/src/opensynth/datasets/low_carbon_london/get_data.py
+++ b/src/opensynth/datasets/low_carbon_london/get_data.py
@@ -48,6 +48,7 @@ def split_preprocess_data(
     historical_end: str,
     future_start: str,
     future_end: str,
+    drop_nulls: bool,
 ):
     """
     Read in, split and preprocess the dataset.
@@ -83,6 +84,8 @@ def split_preprocess_data(
         historical_end (str): End date for historical data.
         future_start (str): Start date for future data.
         future_end (str): End date for future data.
+        drop_nulls (bool): Whether to drop rows with NaN kwh values. If False,
+            will replace NaN kwh values with 0.0
     """
 
     CSV_FILE_NAME = Path(f"{data_dir}/{csv_data_path}")
@@ -115,6 +118,7 @@ def split_preprocess_data(
         datetime_format=datetime_format,
         time_resolution=time_resolution,
         feature_cols=feature_cols,
+        drop_nulls=drop_nulls,
     )
 
 
@@ -140,6 +144,7 @@ if __name__ == "__main__":
     historical_end = "2013-12-31"
     future_start = "2014-01-01"
     future_end = "2014-12-31"
+    drop_nulls = True
 
     split_preprocess_data(
         data_dir,
@@ -156,4 +161,5 @@ if __name__ == "__main__":
         historical_end,
         future_start,
         future_end,
+        drop_nulls,
     )

--- a/src/opensynth/datasets/low_carbon_london/get_data.py
+++ b/src/opensynth/datasets/low_carbon_london/get_data.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from typing import Optional
 
 from opensynth.datasets import datasets_utils
-from opensynth.datasets.low_carbon_london import split_households
-from src.opensynth.datasets.low_carbon_london import preprocess_lcl
+from opensynth.datasets.low_carbon_london import (
+    preprocess_lcl,
+    split_households,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/opensynth/datasets/low_carbon_london/get_data.py
+++ b/src/opensynth/datasets/low_carbon_london/get_data.py
@@ -3,47 +3,155 @@
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 from opensynth.datasets import datasets_utils
-from opensynth.datasets.low_carbon_london import (
-    preprocess_lcl,
-    split_households,
-)
-
-LCL_URL = "https://data.london.gov.uk/download/smartmeter-energy-use-data-in-london-households/3527bf39-d93e-4071-8451-df2ade1ea4f2/LCL-FullData.zip"  # noqa
-FILE_NAME = Path("data/raw/lcl_full_data.zip")  # noqa
-CSV_FILE_NAME = Path("data/raw/CC_LCL-FullData.csv")  # noqa
+from opensynth.datasets.low_carbon_london import split_households
+from src.opensynth.datasets.low_carbon_london import preprocess_lcl
 
 logger = logging.getLogger(__name__)
 
 
-def get_lcl_data(download: bool, split: bool, preprocess: bool):
+def download_lcl_data(data_dir: str = "./data"):
     """
-    Download, split and preprocess the Low Carbon London dataset.
-    Download=True downloads and decompress data from data.london.gov.uk.
-    Split=True splits the LCL households into training and holdout sets.
-    Preprocess=True preprocesses the LCL data into daily load profiles.
-
-    Notes:
-    - The LCL dataset is a large dataset and may take a while to download.
-    - The compressed version of LCL dataset is about 700MB, but the full
+    Download the Low Carbon London (LCL) dataset.
+    The LCL dataset is a large dataset and may take a while to download.
+    The compressed version of LCL dataset is about 700MB, but the full
     dataset size is about 8GB.
-    - Decompression may not work on windows. If so, please manually download
-    and unzip the contents into the `data/raw` folder.
-
+    Decompression may not work on windows. If so, please manually download
+    and unzip the contents into the `{data_dir}/raw` folder.
     Args:
-        download (bool): True to download data from data.london.gov.uk.
-        split (bool): True to split LCL households into training/ holdout sets.
-        preprocess (bool): True to preprocess data.
+        data_dir (str): Directory to save the downloaded data. Defaults to
+            "./data".
+    Returns:
+        None
     """
+    LCL_URL = "https://data.london.gov.uk/download/smartmeter-energy-use-data-in-london-households/3527bf39-d93e-4071-8451-df2ade1ea4f2/LCL-FullData.zip"  # noqa
+    FILE_NAME = Path(f"{data_dir}/raw/lcl_full_data.zip")  # noqa
+    datasets_utils.download_data(LCL_URL, FILE_NAME)
+
+
+def split_preprocess_data(
+    data_dir: str,
+    csv_data_path: str,
+    sample_fraction: float,
+    time_resolution: str,
+    feature_cols: list[str],
+    id_col: str,
+    kwh_col: str,
+    datetime_col: str,
+    utc: bool,
+    datetime_format: Optional[str],
+    historical_start: str,
+    historical_end: str,
+    future_start: str,
+    future_end: str,
+):
+    """
+    Read in, split and preprocess the dataset.
+
+    Requirements:
+    - Dataset needs to be stored in CSV format in {data_dir}/{csv_data_path}.
+    - Dataset needs to have an ID column, a kWh column and a datetime column.
+    - If time_resolution is "half_hourly", data needs to be at half-hourly
+      resolution. If "hourly", data needs to be at hourly resolution.
+    - Datetime column needs to be in a format that can be parsed by
+        pandas.to_datetime, if datetime_format is specified, then this will be
+        parsed into pandas.to_datetime.
+    - kWh column needs to be in numeric format.
+    - feature_cols needs to be a list of columns in the dataset to include as
+      features. These can be categorical or numeric.
+    - historical_start, historical_end, future_start and future_end define
+        the historical and future periods for for TSTR evaluation. Needs to be
+        in the format "YYYY-MM-DD".
+    Args:
+        data_dir (str): Directory to save the processed data.
+        csv_data_path (str): Path to the CSV file containing the dataset.
+        sample_fraction (float): Fraction of households to include in the
+            training set.
+        time_resolution (str): Time resolution of the data. Allowed values:
+            "half_hourly", "hourly".
+        feature_cols (List[str]): List of feature columns to include.
+        id_col (str): Name of the household ID column.
+        kwh_col (str): Name of the kWh column.
+        datetime_col (str): Name of the datetime column.
+        utc (bool): Whether to parse datetime as UTC.
+        datetime_format (str, optional): Format of the datetime column.
+        historical_start (str): Start date for historical data.
+        historical_end (str): End date for historical data.
+        future_start (str): Start date for future data.
+        future_end (str): End date for future data.
+    """
+
+    CSV_FILE_NAME = Path(f"{data_dir}/{csv_data_path}")
     logger.info(
-        f"Running get_lcl_data with download={download}, "
-        f"split={split}, preprocess={preprocess}."
+        f"Reading data from {CSV_FILE_NAME}. Storing data in {data_dir}."
     )
 
-    if download:
-        datasets_utils.download_data(LCL_URL, FILE_NAME)
-    if split:
-        split_households.split_lcl_data(CSV_FILE_NAME, 0.75)
-    if preprocess:
-        preprocess_lcl.preprocess_lcl_data()
+    # Split dataset into training/ holdout sets
+    split_households.split_data(
+        data_dir,
+        CSV_FILE_NAME,
+        sample_fraction=sample_fraction,
+        id_col=id_col,
+        kwh_col=kwh_col,
+        datetime_col=datetime_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        historical_start=historical_start,
+        historical_end=historical_end,
+        future_start=future_start,
+        future_end=future_end,
+    )
+    # Preprocess the data into daily load profiles
+    preprocess_lcl.preprocess_data(
+        data_dir,
+        datetime_col=datetime_col,
+        kwh_col=kwh_col,
+        id_col=id_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        time_resolution=time_resolution,
+        feature_cols=feature_cols,
+    )
+
+
+if __name__ == "__main__":
+    data_dir = "./data"
+
+    sample_fraction = 0.75
+
+    # Dataset location
+    csv_data_path = "raw/CC_LCL-FullData.csv"
+
+    # Dataset parameters
+    # Adjust these parameters if using a different dataset
+    # Parameters defined here are for the LCL dataset
+    time_resolution = "half_hourly"
+    feature_cols = ["stdorToU"]
+    id_col = "LCLid"
+    kwh_col = "KWH/hh (per half hour) "
+    date_col = "DateTime"
+    utc = False
+    datetime_format = None
+    historical_start = "2012-01-01"
+    historical_end = "2013-12-31"
+    future_start = "2014-01-01"
+    future_end = "2014-12-31"
+
+    split_preprocess_data(
+        data_dir,
+        csv_data_path,
+        sample_fraction,
+        time_resolution,
+        feature_cols,
+        id_col,
+        kwh_col,
+        date_col,
+        utc,
+        datetime_format,
+        historical_start,
+        historical_end,
+        future_start,
+        future_end,
+    )

--- a/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
+++ b/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
@@ -154,13 +154,16 @@ def parse_settlement_period(
     return df_out
 
 
-def drop_dupes_and_replace_nulls(df: pd.DataFrame) -> pd.DataFrame:
+def drop_dupes_and_nulls(
+    df: pd.DataFrame, drop_nulls: bool = True
+) -> pd.DataFrame:
     """
     Function to drop duplicated readings and replace missing readings with 0.0
 
     Args:
         df (pd.DataFrame): Input dataframe
-
+        drop_nulls (bool): Whether to drop rows with NaN kwh values. If False,
+            will replace NaN kwh values with 0.0
     Returns:
         pd.DataFrame: Output dataframe
     """
@@ -172,7 +175,10 @@ def drop_dupes_and_replace_nulls(df: pd.DataFrame) -> pd.DataFrame:
     df_out = df_out.drop_duplicates(
         subset=["ID", "date", "settlement_period"], keep="last"
     )
-    df_out = df_out.dropna()
+    if drop_nulls:
+        df_out = df_out.dropna(subset="kwh")
+    else:
+        df_out["kwh"] = df_out["kwh"].fillna(0.0)
     return df_out
 
 
@@ -324,6 +330,7 @@ def preprocess_pipeline(
     datetime_format: Optional[str] = None,
     time_resolution: str = "half_hourly",
     feature_cols: List[str] = ["stdorToU"],
+    drop_nulls: bool = True,
 ):
     """Preprocess the raw data for Faraday training and evaluation.
     Pipeline includes:
@@ -347,13 +354,15 @@ def preprocess_pipeline(
             values: "half_hourly", "hourly". Defaults to "half_hourly".
         feature_cols (List[str], optional): List of feature columns to include.
             Defaults to ["stdorToU"].
+        drop_nulls (bool): Whether to drop rows with NaN kwh values. If False,
+            will replace NaN kwh values with 0.0
     """
 
     df = load_data(file_path)
     df = format_data(df, datetime_col, kwh_col, id_col, utc, datetime_format)
     df = extract_date_features(df)
     df = parse_settlement_period(df)
-    df = drop_dupes_and_replace_nulls(df)
+    df = drop_dupes_and_nulls(df, drop_nulls)
     df = filter_missing_kwh(df, time_resolution)
 
     mean, stdev = get_mean_and_std(df)
@@ -381,6 +390,7 @@ def preprocess_data(
     datetime_format: Optional[str] = None,
     time_resolution: str = "half_hourly",
     feature_cols: List[str] = ["stdorToU"],
+    drop_nulls: bool = True,
 ):
 
     SOURCE_DIR = f"{data_dir}/raw"
@@ -395,6 +405,7 @@ def preprocess_data(
         datetime_format=datetime_format,
         time_resolution=time_resolution,
         feature_cols=feature_cols,
+        drop_nulls=drop_nulls,
     )
     preprocess_pipeline(
         file_path=Path(f"{SOURCE_DIR}/historical/holdout.csv"),
@@ -406,6 +417,7 @@ def preprocess_data(
         datetime_format=datetime_format,
         time_resolution=time_resolution,
         feature_cols=feature_cols,
+        drop_nulls=drop_nulls,
     )
     preprocess_pipeline(
         file_path=Path(f"{SOURCE_DIR}/future/train.csv"),
@@ -417,6 +429,7 @@ def preprocess_data(
         datetime_format=datetime_format,
         time_resolution=time_resolution,
         feature_cols=feature_cols,
+        drop_nulls=drop_nulls,
     )
     preprocess_pipeline(
         file_path=Path(f"{SOURCE_DIR}/future/holdout.csv"),
@@ -428,4 +441,5 @@ def preprocess_data(
         datetime_format=datetime_format,
         time_resolution=time_resolution,
         feature_cols=feature_cols,
+        drop_nulls=drop_nulls,
     )

--- a/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
+++ b/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
@@ -167,7 +167,7 @@ def drop_dupes_and_nulls(
     Returns:
         pd.DataFrame: Output dataframe
     """
-    logger.info("🗑 Dropping dupes and nulls")
+    logger.info("🗑 Dropping dupes")
     df_out = df.copy()
     df_out = df_out.sort_values(
         by=["ID", "date", "settlement_period"], ascending=True
@@ -176,8 +176,10 @@ def drop_dupes_and_nulls(
         subset=["ID", "date", "settlement_period"], keep="last"
     )
     if drop_nulls:
+        logger.info("🗑 Dropping nulls")
         df_out = df_out.dropna(subset="kwh")
     else:
+        logger.info("🗑 Filling nulls with 0.0")
         df_out["kwh"] = df_out["kwh"].fillna(0.0)
     return df_out
 

--- a/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
+++ b/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
@@ -44,19 +44,34 @@ def get_current_month_end(df: pd.DataFrame, date_col="dt"):
     return df
 
 
-def load_data(
-    file_path: Path,
+def load_data(file_path: Path) -> pd.DataFrame:
+    """
+    Load data from csv
+
+    Args:
+        file_path (Path): Path to the csv file
+
+    Returns:
+        pd.DataFrame: dataset
+    """
+    logger.info(f"🚛 Loading data from {file_path}")
+    df = pd.read_csv(file_path)
+    return df
+
+
+def format_data(
+    df: pd.DataFrame,
     datetime_col: str,
     kwh_col: str,
     id_col: str,
-    utc: bool,
-    datetime_format: Optional[str],
+    utc: bool = True,
+    datetime_format: Optional[str] = None,
 ) -> pd.DataFrame:
     """
     Load data from csv
 
     Args:
-        files_path (str): Folder containing CSV files
+        df (pd.DataFrame): Dataset
         datetime_col (str): Name of the datetime column
         kwh_col (str): Name of the kWh column
         id_col (str): Name of the household ID column
@@ -67,8 +82,6 @@ def load_data(
     Returns:
         pd.DataFrame: dataset
     """
-    logger.info(f"🚛 Loading data from {file_path}")
-    df = pd.read_csv(file_path)
 
     logger.info("🧹 Formatting data")
     df.rename(
@@ -81,7 +94,6 @@ def load_data(
     df["kwh"] = df["kwh"].replace("Null", np.nan)
     df["kwh"] = df["kwh"].astype(float)
     df["ID"] = df["ID"].astype(str)
-
     return df
 
 
@@ -160,11 +172,13 @@ def drop_dupes_and_replace_nulls(df: pd.DataFrame) -> pd.DataFrame:
     df_out = df_out.drop_duplicates(
         subset=["ID", "date", "settlement_period"], keep="last"
     )
-    df_out = df_out.replace("Null", np.float64())
+    df_out = df_out.dropna()
     return df_out
 
 
-def filter_missing_kwh(df: pd.DataFrame, time_resolution: str) -> pd.DataFrame:
+def filter_missing_kwh(
+    df: pd.DataFrame, time_resolution: str = "half_hourly"
+) -> pd.DataFrame:
     """
     Drop dates where we don't have full 48 readings if half-hourly data,
     or 24 readings if hourly data, for a given ID and date.
@@ -329,9 +343,8 @@ def preprocess_pipeline(
             Defaults to ["stdorToU"].
     """
 
-    df = load_data(
-        file_path, datetime_col, kwh_col, id_col, utc, datetime_format
-    )
+    df = load_data(file_path)
+    df = format_data(df, datetime_col, kwh_col, id_col, utc, datetime_format)
     df = extract_date_features(df)
     df = parse_settlement_period(df)
     df = drop_dupes_and_replace_nulls(df)

--- a/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
+++ b/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
@@ -5,7 +5,7 @@ import csv
 import logging
 import os
 from pathlib import Path
-from typing import Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -44,19 +44,44 @@ def get_current_month_end(df: pd.DataFrame, date_col="dt"):
     return df
 
 
-def load_data(file_path: Path) -> pd.DataFrame:
+def load_data(
+    file_path: Path,
+    datetime_col: str,
+    kwh_col: str,
+    id_col: str,
+    utc: bool,
+    datetime_format: Optional[str],
+) -> pd.DataFrame:
     """
-    Load LCL data from csv
+    Load data from csv
 
     Args:
         files_path (str): Folder containing CSV files
+        datetime_col (str): Name of the datetime column
+        kwh_col (str): Name of the kWh column
+        id_col (str): Name of the household ID column
+        utc (bool): Whether the datetime is in UTC
+        datetime_format (str, optional): Format of the datetime column. If
+            None, will try to infer the format. Defaults to None.
 
     Returns:
-        pd.DataFrame: LCL dataset
+        pd.DataFrame: dataset
     """
     logger.info(f"🚛 Loading data from {file_path}")
     df = pd.read_csv(file_path)
-    df = df.rename(columns={"KWH/hh (per half hour) ": "kwh"})
+
+    logger.info("🧹 Formatting data")
+    df.rename(
+        columns={datetime_col: "DateTime", kwh_col: "kwh", id_col: "ID"},
+        inplace=True,
+    )
+    df["DateTime"] = pd.to_datetime(
+        df["DateTime"], utc=utc, format=datetime_format
+    )
+    df["kwh"] = df["kwh"].replace("Null", np.nan)
+    df["kwh"] = df["kwh"].astype(float)
+    df["ID"] = df["ID"].astype(str)
+
     return df
 
 
@@ -130,46 +155,60 @@ def drop_dupes_and_replace_nulls(df: pd.DataFrame) -> pd.DataFrame:
     logger.info("🗑 Dropping dupes and filling nulls with 0")
     df_out = df.copy()
     df_out = df_out.sort_values(
-        by=["LCLid", "date", "settlement_period"], ascending=True
+        by=["ID", "date", "settlement_period"], ascending=True
     )
     df_out = df_out.drop_duplicates(
-        subset=["LCLid", "date", "settlement_period"], keep="last"
+        subset=["ID", "date", "settlement_period"], keep="last"
     )
-    df_out["kwh"] = df_out["kwh"].replace("Null", np.float64())
-    df_out["kwh"] = df_out["kwh"].astype(float)
+    df_out = df_out.replace("Null", np.float64())
     return df_out
 
 
-def filter_missing_kwh(df: pd.DataFrame) -> pd.DataFrame:
+def filter_missing_kwh(df: pd.DataFrame, time_resolution: str) -> pd.DataFrame:
     """
-    Drop dates where we don't have full 48 readings
-    for a given LCLid and date.
+    Drop dates where we don't have full 48 readings if half-hourly data,
+    or 24 readings if hourly data, for a given ID and date.
 
     Args:
-        df (pd.DataFrame): _description_
+        df (pd.DataFrame): dataset
+        time_resolution (str): Time resolution of the data. Allowed values:
+            "half_hourly", "hourly".
 
     Returns:
-        pd.DataFrame: _description_
+        pd.DataFrame: filtered dataset
     """
     logger.info("🔍 Filtering missing kwh readings")
-    id_col = ["LCLid"]
-    merge_cols = id_col + ["date"]
+    merge_cols = ["ID", "date"]
     df_group = df.groupby(merge_cols)[["kwh"]].count().reset_index()
-    df_group["required_len"] = 48  # 48 hh readings
+
+    if time_resolution == "half_hourly":
+        required_len = 48  # 48 hh readings
+    elif time_resolution == "hourly":
+        required_len = 24  # 24 h readings
+    else:
+        raise ValueError("time_resolution must be 'half_hourly' or 'hourly'")
+    df_group["required_len"] = required_len
 
     df_full_data = df_group.query("required_len==kwh")  # Has all required data
     df_out = df_full_data[merge_cols].merge(df, on=merge_cols, how="inner")
+
+    assert len(df_out) > 0, "No data left after filtering missing kwh readings"
     return df_out
 
 
-def pack_smart_meter_data_into_arrays(df: pd.DataFrame) -> pd.DataFrame:
+def pack_smart_meter_data_into_arrays(
+    df: pd.DataFrame, feature_cols: List[str]
+) -> pd.DataFrame:
     """
-    Pack smart meter data into 48-dimensional arrays.
+    Pack smart meter data into 48- or 24-dimensional arrays,
+    depending on whether half-hourly or hourly data.
     Note: LCL dataset are all given in UTC. We should expect
     48-readings per day.
 
     Args:
         df (pd.DataFrame): Input dataframe
+        feature_cols (List[str]): List of feature columns to include in
+            processed dataset.
 
     Returns:
         pd.DataFrame: Output dataframe
@@ -177,9 +216,9 @@ def pack_smart_meter_data_into_arrays(df: pd.DataFrame) -> pd.DataFrame:
     logger.info("👝 Packing time series into arrays")
     df_out = df.copy()
     df_out = df_out.sort_values(
-        by=["LCLid", "date", "settlement_period"], ascending=True
+        by=["ID", "date", "settlement_period"], ascending=True
     )
-    groupby_cols = ["LCLid", "stdorToU", "month_end", "month"]
+    groupby_cols = ["ID", "month_end", "month"] + feature_cols
     groupby_cols = groupby_cols + ["dayofweek", "day", "date"]
 
     df_out = pd.DataFrame(
@@ -207,7 +246,7 @@ def get_mean_and_std(df: pd.DataFrame) -> Tuple[float, float]:
 
 
 def create_outliers(
-    df: pd.DataFrame, mean: float, mean_factor: int = 20
+    df: pd.DataFrame, time_resolution: str, mean: float, mean_factor: int = 20
 ) -> pd.DataFrame:
     """
     Function to generate outliers based on gaussian and gamma distribution.
@@ -222,12 +261,19 @@ def create_outliers(
         pd.DataFrame: Dataframe consisting of noisy outliers
     """
 
+    if time_resolution == "half_hourly":
+        n = 48
+    elif time_resolution == "hourly":
+        n = 24
+    else:
+        raise ValueError("time_resolution must be 'half_hourly' or 'hourly'")
+
     gaussian_generator = NoiseFactory(
         noise_type=NoiseType.GAUSSIAN,
         mean=mean,
         scale=1.0,
         mean_factor=mean_factor,
-        size=(50, 48),
+        size=(50, n),
     )
 
     gamma_generator = NoiseFactory(
@@ -235,7 +281,7 @@ def create_outliers(
         mean=mean,
         scale=1.0,
         mean_factor=mean_factor,
-        size=(50, 48),
+        size=(50, n),
     )
     logger.info(
         "🎲 Generating unseen outliers with mean:"
@@ -248,21 +294,56 @@ def create_outliers(
     return df_noise
 
 
-def preprocess_pipeline(file_path: Path, out_path: Path):
+def preprocess_pipeline(
+    file_path: Path,
+    out_path: Path,
+    datetime_col: str = "DateTime",
+    kwh_col: str = "kwh",
+    id_col: str = "ID",
+    utc: bool = True,
+    datetime_format: Optional[str] = None,
+    time_resolution: str = "half_hourly",
+    feature_cols: List[str] = ["stdorToU"],
+):
+    """Preprocess the raw data for Faraday training and evaluation.
+    Pipeline includes:
+    - Data cleaning
+    - Extraction of time features (day of week, month of year)
+    - Injection of outliers into dataset
+    - Calculation of mean and std for normalisation in Faraday
+    - Re-structung the dataset so that each row corresponds to a daily load
+        profile.
 
-    df = load_data(file_path)
+    Args:
+        file_path (Path): Path to the raw CSV file
+        out_path (Path): Path to save the processed data
+        datetime_col (str, optional): datetime column. Defaults to "DateTime".
+        kwh_col (str, optional): kWh column. Defaults to "kwh".
+        id_col (str, optional): Household ID column. Defaults to "ID".
+        utc (bool, optional): Whether the datetime is in UTC. Defaults to True.
+        datetime_format (str, optional): Format of the datetime column. If
+            None, will try to infer the format. Defaults to None.
+        time_resolution (str, optional): Time resolution of the data. Allowed
+            values: "half_hourly", "hourly". Defaults to "half_hourly".
+        feature_cols (List[str], optional): List of feature columns to include.
+            Defaults to ["stdorToU"].
+    """
+
+    df = load_data(
+        file_path, datetime_col, kwh_col, id_col, utc, datetime_format
+    )
     df = extract_date_features(df)
     df = parse_settlement_period(df)
     df = drop_dupes_and_replace_nulls(df)
-    df = filter_missing_kwh(df)
+    df = filter_missing_kwh(df, time_resolution)
 
     mean, stdev = get_mean_and_std(df)
-    df = pack_smart_meter_data_into_arrays(df)
+    df = pack_smart_meter_data_into_arrays(df, feature_cols)
 
-    df_noise = create_outliers(df, mean)
+    df_noise = create_outliers(df, time_resolution, mean)
 
     os.makedirs(out_path, exist_ok=True)
-    df.to_csv(f"{out_path}/lcl_data.csv", index=False)
+    df.to_csv(f"{out_path}/data.csv", index=False)
     df_noise.to_csv(f"{out_path}/outliers.csv", index=False)
 
     mean_std_dict = {"mean": mean, "stdev": stdev}
@@ -272,27 +353,60 @@ def preprocess_pipeline(file_path: Path, out_path: Path):
         w.writerow(mean_std_dict)
 
 
-def preprocess_lcl_data():
+def preprocess_data(
+    data_dir: str,
+    datetime_col: str = "DateTime",
+    kwh_col: str = "kwh",
+    id_col: str = "ID",
+    utc: bool = True,
+    datetime_format: Optional[str] = None,
+    time_resolution: str = "half_hourly",
+    feature_cols: List[str] = ["stdorToU"],
+):
 
-    SOURCE_DIR = "data/raw"
-    OUT_DIR = "data/processed"
+    SOURCE_DIR = f"{data_dir}/raw"
+    OUT_DIR = f"{data_dir}/processed"
     preprocess_pipeline(
-        file_path=f"{SOURCE_DIR}/historical/train.csv",
-        out_path=f"{OUT_DIR}/historical/train",
+        file_path=Path(f"{SOURCE_DIR}/historical/train.csv"),
+        out_path=Path(f"{OUT_DIR}/historical/train"),
+        datetime_col=datetime_col,
+        kwh_col=kwh_col,
+        id_col=id_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        time_resolution=time_resolution,
+        feature_cols=feature_cols,
     )
     preprocess_pipeline(
-        file_path=f"{SOURCE_DIR}/historical/holdout.csv",
-        out_path=f"{OUT_DIR}/historical/holdout",
+        file_path=Path(f"{SOURCE_DIR}/historical/holdout.csv"),
+        out_path=Path(f"{OUT_DIR}/historical/holdout"),
+        datetime_col=datetime_col,
+        kwh_col=kwh_col,
+        id_col=id_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        time_resolution=time_resolution,
+        feature_cols=feature_cols,
     )
     preprocess_pipeline(
-        file_path=f"{SOURCE_DIR}/future/train.csv",
-        out_path=f"{OUT_DIR}/future/train",
+        file_path=Path(f"{SOURCE_DIR}/future/train.csv"),
+        out_path=Path(f"{OUT_DIR}/future/train"),
+        datetime_col=datetime_col,
+        kwh_col=kwh_col,
+        id_col=id_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        time_resolution=time_resolution,
+        feature_cols=feature_cols,
     )
     preprocess_pipeline(
-        file_path=f"{SOURCE_DIR}/future/holdout.csv",
-        out_path=f"{OUT_DIR}/future/holdout",
+        file_path=Path(f"{SOURCE_DIR}/future/holdout.csv"),
+        out_path=Path(f"{OUT_DIR}/future/holdout"),
+        datetime_col=datetime_col,
+        kwh_col=kwh_col,
+        id_col=id_col,
+        utc=utc,
+        datetime_format=datetime_format,
+        time_resolution=time_resolution,
+        feature_cols=feature_cols,
     )
-
-
-if __name__ == "__main__":
-    preprocess_lcl_data()

--- a/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
+++ b/src/opensynth/datasets/low_carbon_london/preprocess_lcl.py
@@ -91,7 +91,7 @@ def format_data(
     df["DateTime"] = pd.to_datetime(
         df["DateTime"], utc=utc, format=datetime_format
     )
-    df["kwh"] = df["kwh"].replace("Null", np.nan)
+    df["kwh"] = df["kwh"].replace("Null", np.nan)  # Replace "Null" with np.nan
     df["kwh"] = df["kwh"].astype(float)
     df["ID"] = df["ID"].astype(str)
     return df
@@ -164,7 +164,7 @@ def drop_dupes_and_replace_nulls(df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         pd.DataFrame: Output dataframe
     """
-    logger.info("🗑 Dropping dupes and filling nulls with 0")
+    logger.info("🗑 Dropping dupes and nulls")
     df_out = df.copy()
     df_out = df_out.sort_values(
         by=["ID", "date", "settlement_period"], ascending=True
@@ -200,13 +200,19 @@ def filter_missing_kwh(
     elif time_resolution == "hourly":
         required_len = 24  # 24 h readings
     else:
-        raise ValueError("time_resolution must be 'half_hourly' or 'hourly'")
+        raise ValueError(
+            f"time_resolution must be 'half_hourly' or 'hourly', \
+        got {time_resolution}"
+        )
     df_group["required_len"] = required_len
 
     df_full_data = df_group.query("required_len==kwh")  # Has all required data
     df_out = df_full_data[merge_cols].merge(df, on=merge_cols, how="inner")
 
-    assert len(df_out) > 0, "No data left after filtering missing kwh readings"
+    if len(df_out) == 0:
+        raise ValueError(
+            "No data left after filtering days with missing kWh readings"
+        )
     return df_out
 
 
@@ -325,7 +331,7 @@ def preprocess_pipeline(
     - Extraction of time features (day of week, month of year)
     - Injection of outliers into dataset
     - Calculation of mean and std for normalisation in Faraday
-    - Re-structung the dataset so that each row corresponds to a daily load
+    - Re-structuring the dataset so that each row corresponds to a daily load
         profile.
 
     Args:

--- a/src/opensynth/datasets/low_carbon_london/split_households.py
+++ b/src/opensynth/datasets/low_carbon_london/split_households.py
@@ -5,8 +5,9 @@ import logging
 import os
 import random
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
+import numpy as np
 import pandas as pd
 
 random.seed(42)
@@ -20,12 +21,13 @@ def split_household_ids(
     sample_fraction: float = 0.75,
 ) -> Tuple[List[str], List[str]]:
     """
-    Split LCL id into training vs holdout households.
+    Split dataset into training vs holdout households.
 
     Args:
-        df (pd.DataFrame): LCL dataset
-        id_col (str): ID column
-        sample_fraction (float): Fraction of household ids to include in training set
+        df (pd.DataFrame): dataset
+        id_col (str): Name of the household ID column
+        sample_fraction (float): Fraction of household ids to include in
+        training set
 
     Returns:
         Tuple[List[str], List[str]]: List of training and holdout household ids
@@ -42,77 +44,148 @@ def split_household_ids(
 
 
 def split_historical_future_periods(
-    df: pd.DataFrame, date_col: str = "DateTime"
+    df: pd.DataFrame,
+    datetime_col: str,
+    historical_start: str,
+    historical_end: str,
+    future_start: str,
+    future_end: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
-    Splits LCL dataset into:
-     1) historical period (1st Jan 2012 to 31st Dec 2013)
-     2) future period (after 1st Jan 2014)
-
-     These periods are used for TSTR evaluation.
+    Splits dataset into:
+     1) historical period
+     2) future period
+    These periods are used for TSTR evaluation.
 
     Args:
         df (pd.DataFrame): pd.DataFrame
-        date_col (str, optional): Name of date column. Defaults to "DateTime".
+        datetime_col (str): Name of the datetime column
+        historical_start (str): Start date for historical period
+        historical_end (str): End date for historical period
+        future_start (str): Start date for future period
+        future_end (str): End date for future period
 
     Returns:
         Tuple[pd.DataFrame, pd.DataFrame]: Historical and Future dataframe.
     """
-    historical_start = df[date_col] >= "2012-01-01"
-    historical_end = df[date_col] <= "2013-12-31"
-    tstr_historical_mask = historical_start & historical_end
+    # Format the start and end dates to include time information
+    historical_start = pd.Timestamp(historical_start).replace(
+        hour=00, minute=00, second=00
+    )
+    historical_end = pd.Timestamp(historical_end).replace(
+        hour=23, minute=59, second=59
+    )
+    future_start = pd.Timestamp(future_start).replace(
+        hour=00, minute=00, second=00
+    )
+    future_end = pd.Timestamp(future_end).replace(
+        hour=23, minute=59, second=59
+    )
 
-    future_start = df[date_col] >= "2014-01-01"
-    future_end = df[date_col] <= "2014-12-31"
-    tstr_future_mask = future_start & future_end
+    historical_start_mask = df[datetime_col] >= historical_start
+    historical_end_mask = df[datetime_col] <= historical_end
+    tstr_historical_mask = historical_start_mask & historical_end_mask
+
+    future_start_mask = df[datetime_col] >= future_start
+    future_end_mask = df[datetime_col] <= future_end
+    tstr_future_mask = future_start_mask & future_end_mask
 
     df_historical = df.loc[tstr_historical_mask]
     df_future = df.loc[tstr_future_mask]
     return df_historical, df_future
 
 
-def split_lcl_data(csv_filename: Path, sample_fraction: float = 0.75):
+def split_data(
+    data_dir: str,
+    csv_filename: Path,
+    sample_fraction: float = 0.75,
+    id_col: str = "ID",
+    kwh_col: str = "kwh",
+    datetime_col: str = "DateTime",
+    utc=True,
+    datetime_format: Optional[str] = None,
+    historical_start: str = "2012-01-01",
+    historical_end: str = "2013-12-31",
+    future_start: str = "2014-01-01",
+    future_end: str = "2015-12-31",
+) -> None:
     """
-    Split LCL dataset 4 ways:
+    Split the dataset 4 ways:
     1) Historical Train household data
     2) Historical Holdout household data
     3) Future Train household data
     4) Future Holdout household data
 
     Historical data is used for training generative models.
-    Future data is used for TSTR evaluation.
+    Future data is used for Train-Synthetic-Test-Real (TSTR) evaluation.
 
     Args:
-        sample_fraction (float): _description_. Defaults to 0.75.
+        data_dir (str): Directory to store the processed data.
+        csv_filename (Path): Path to the CSV file containing the raw data.
+        sample_fraction (float): Fraction of households to include in the
+            training set. Defaults to 0.75.
+        id_col (str): Name of the household ID column. Defaults to "LCLid".
+        kwh_col (str): Name of the kWh column. Defaults to
+            "KWH/hh (per half hour) ".
+        datetime_col (str): Name of the datetime column. Defaults to
+            "DateTime".
+        utc (bool): Whether to parse datetime as UTC. Defaults to False.
+        datetime_format (str, optional): Format of the datetime column.
+            Defaults to None.
+        historical_start (str): Start date for historical data. Defaults to
+            "2012-01-01".
+        historical_end (str): End date for historical data. Defaults to
+            "2013-12-31".
+        future_start (str): Start date for future data. Defaults to
+            "2014-01-01".
+        future_end (str): End date for future data. Defaults to "2014-12-31".
+    Returns:
+        None
     """
 
-    logger.info(f"👀 Reading LCL data from: {csv_filename}")
+    logger.info(f"👀 Reading data from: {csv_filename}")
     df = pd.read_csv(csv_filename)
+
+    logger.info("🧹 Formatting data")
+    df[datetime_col] = pd.to_datetime(
+        df[datetime_col], utc=utc, format=datetime_format
+    )
+    df[kwh_col] = df[kwh_col].replace("Null", np.float64())
+    df[kwh_col] = df[kwh_col].astype(float)
+    df[id_col] = df[id_col].astype(str)
 
     logger.info("🖖 Spliting households into train and holdout")
     train_ids, holdout_ids = split_household_ids(
         df,
-        id_col="LCLid",
+        id_col,
         sample_fraction=sample_fraction,
     )
     logger.info(f"Train len: {len(train_ids)}")
     logger.info(f"Holdout len: {len(holdout_ids)}")
 
     logger.info("📆 Splitting data into train and holdout period")
-    df_history, df_future = split_historical_future_periods(df)
+    df_history, df_future = split_historical_future_periods(
+        df,
+        datetime_col,
+        historical_start,
+        historical_end,
+        future_start,
+        future_end,
+    )
     logger.info(f"History len: {len(df_history)}")
     logger.info(f"Future len: {len(df_future)}")
 
-    df_historical_train = df_history[df_history["LCLid"].isin(train_ids)]
-    df_future_train = df_future[df_future["LCLid"].isin(train_ids)]
-    df_historical_holdout = df_history[df_history["LCLid"].isin(holdout_ids)]
-    df_future_holdout = df_future[df_future["LCLid"].isin(holdout_ids)]
+    df_historical_train = df_history[df_history[id_col].isin(train_ids)]
+    df_future_train = df_future[df_future[id_col].isin(train_ids)]
+    df_historical_holdout = df_history[df_history[id_col].isin(holdout_ids)]
+    df_future_holdout = df_future[df_future[id_col].isin(holdout_ids)]
 
     logger.info("📦 Saving train and holdout data")
-    historical_path = Path("data/raw/historical")
-    future_path = Path("data/raw/future")
+    historical_path = Path(f"{data_dir}/raw/historical")
+    future_path = Path(f"{data_dir}/raw/future")
     os.makedirs(historical_path, exist_ok=True)
     os.makedirs(future_path, exist_ok=True)
+
     df_historical_train.to_csv(
         f"{historical_path}/train.csv",
         index=False,

--- a/tests/datasets/low_carbon_london/test_preprocess_lcl.py
+++ b/tests/datasets/low_carbon_london/test_preprocess_lcl.py
@@ -4,13 +4,16 @@ import pandas as pd
 import pytest
 
 from opensynth.datasets.low_carbon_london import preprocess_lcl
-from tests.utils import df_test
+from tests.utils import df_test_half_hourly, df_test_hourly
 
 
 class TestPreprocessLCL:
 
     df = preprocess_lcl.format_data(
-        df_test(), datetime_col="DateTime", kwh_col="kwh", id_col="LCLid"
+        df_test_half_hourly(),
+        datetime_col="DateTime",
+        kwh_col="kwh",
+        id_col="LCLid",
     )
     df_date = preprocess_lcl.extract_date_features(df)
     df_settlement_period = preprocess_lcl.parse_settlement_period(df_date)
@@ -79,8 +82,8 @@ class TestPreprocessLCL:
     def test_filter_missing_kwh(self):
         # test_df is filled with only 1 kwh per date reading
         # filter_missing_kwh checks that each date has 48 readings
-        # and drop dates with < 48 readings
-        with pytest.raises(AssertionError):
+        # and drop dates with < 24 or 48 readings depending on time resolution
+        with pytest.raises(ValueError):
             _ = preprocess_lcl.filter_missing_kwh(self.df_drop_dupes)
 
     def test_pack_smart_meter_data_into_arrays(self):
@@ -92,3 +95,85 @@ class TestPreprocessLCL:
         assert df_packed.query("ID=='MAC000002' and month==1 and day==15")[
             "kwh"
         ].values.tolist()[0] == [0.4, 0.4, 0.5, 0.6]
+
+
+class TestPreprocessHourlykWh:
+
+    df = preprocess_lcl.format_data(
+        df_test_hourly(),
+        datetime_col="DateTime",
+        kwh_col="kwh",
+        id_col="LCLid",
+    )
+    df_date = preprocess_lcl.extract_date_features(df)
+    df_settlement_period = preprocess_lcl.parse_settlement_period(df_date)
+    df_drop_dupes = preprocess_lcl.drop_dupes_and_replace_nulls(
+        df_settlement_period
+    )
+
+    def test_week(self):
+        expected_week = pd.to_datetime(
+            [
+                datetime(2013, 1, 1),
+            ]
+            * 48
+        )
+        assert (self.df_date["week"] == expected_week).all()
+
+    def test_month_end(self):
+        expected_month_end = pd.to_datetime(
+            [
+                datetime(2013, 1, 31),
+            ]
+            * 48
+        )
+        assert (self.df_date["month_end"] == expected_month_end).all()
+
+    def test_month_max(self):
+        expected_month_max = [31] * 48
+        assert (self.df_date["month_max"] == expected_month_max).all()
+
+    def test_day_of_week(self):
+        expected_day_of_week = [3] * 24 + [4] * 24
+        assert (self.df_date["dayofweek"] == expected_day_of_week).all()
+
+    def test_parse_settlement_period(self):
+        expected_settlement_period = list(range(1, 49, 2)) * 2
+        assert (
+            self.df_settlement_period["settlement_period"]
+            == expected_settlement_period
+        ).all()
+
+    def test_drop_dupes_and_replace_nulls(self):
+        assert len(self.df_drop_dupes) == 48
+        # assert self.df_drop_dupes["kwh"].sum() == pytest.approx(2.3)
+
+    def test_filter_missing_kwh(self):
+        # No missing data expected
+        df = preprocess_lcl.filter_missing_kwh(
+            self.df_drop_dupes, time_resolution="hourly"
+        )
+        assert len(df) == 48
+
+    def test_pack_smart_meter_data_into_arrays(self):
+        df_packed = preprocess_lcl.pack_smart_meter_data_into_arrays(
+            self.df_drop_dupes,
+            feature_cols=["stdorToU"],
+        )
+        assert len(df_packed) == 2
+        assert (
+            len(
+                df_packed.query("ID=='MAC000002' and month==1 and day==3")[
+                    "kwh"
+                ].values.tolist()[0]
+            )
+            == 24
+        )
+        assert (
+            len(
+                df_packed.query("ID=='MAC000002' and month==1 and day==4")[
+                    "kwh"
+                ].values.tolist()[0]
+            )
+            == 24
+        )

--- a/tests/datasets/low_carbon_london/test_preprocess_lcl.py
+++ b/tests/datasets/low_carbon_london/test_preprocess_lcl.py
@@ -17,9 +17,7 @@ class TestPreprocessLCL:
     )
     df_date = preprocess_lcl.extract_date_features(df)
     df_settlement_period = preprocess_lcl.parse_settlement_period(df_date)
-    df_drop_dupes = preprocess_lcl.drop_dupes_and_replace_nulls(
-        df_settlement_period
-    )
+    df_drop_dupes = preprocess_lcl.drop_dupes_and_nulls(df_settlement_period)
 
     def test_week(self):
         expected_week = pd.to_datetime(
@@ -75,9 +73,20 @@ class TestPreprocessLCL:
             == expected_settlement_period
         ).all()
 
-    def test_drop_dupes_and_replace_nulls(self):
+    def test_drop_dupes_and_nulls(self):
+        # Testing the original function that drops duplicates and nulls
+        # Expect duplicated row and null row dropped
         assert len(self.df_drop_dupes) == 6
         assert self.df_drop_dupes["kwh"].sum() == pytest.approx(2.3)
+
+    def test_replace_nulls(self):
+        # Testing the original function that replaces nulls with 0
+        df_drop_dupes = preprocess_lcl.drop_dupes_and_nulls(
+            self.df_settlement_period, drop_nulls=False
+        )
+        # Expect duplicated row dropped, but null replaced with 0
+        assert len(df_drop_dupes) == 7
+        assert df_drop_dupes["kwh"].sum() == pytest.approx(2.3)
 
     def test_filter_missing_kwh(self):
         # test_df is filled with only 1 kwh per date reading
@@ -107,9 +116,7 @@ class TestPreprocessHourlykWh:
     )
     df_date = preprocess_lcl.extract_date_features(df)
     df_settlement_period = preprocess_lcl.parse_settlement_period(df_date)
-    df_drop_dupes = preprocess_lcl.drop_dupes_and_replace_nulls(
-        df_settlement_period
-    )
+    df_drop_dupes = preprocess_lcl.drop_dupes_and_nulls(df_settlement_period)
 
     def test_week(self):
         expected_week = pd.to_datetime(
@@ -144,7 +151,7 @@ class TestPreprocessHourlykWh:
             == expected_settlement_period
         ).all()
 
-    def test_drop_dupes_and_replace_nulls(self):
+    def test_drop_dupes_and_nulls(self):
         assert len(self.df_drop_dupes) == 48
         # assert self.df_drop_dupes["kwh"].sum() == pytest.approx(2.3)
 

--- a/tests/datasets/low_carbon_london/test_preprocess_lcl.py
+++ b/tests/datasets/low_carbon_london/test_preprocess_lcl.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pandas as pd
+import pytest
 
 from opensynth.datasets.low_carbon_london import preprocess_lcl
 from tests.utils import df_test
@@ -8,12 +9,14 @@ from tests.utils import df_test
 
 class TestPreprocessLCL:
 
-    df_date = preprocess_lcl.extract_date_features(df_test())
+    df = preprocess_lcl.format_data(
+        df_test(), datetime_col="DateTime", kwh_col="kwh", id_col="LCLid"
+    )
+    df_date = preprocess_lcl.extract_date_features(df)
     df_settlement_period = preprocess_lcl.parse_settlement_period(df_date)
     df_drop_dupes = preprocess_lcl.drop_dupes_and_replace_nulls(
         df_settlement_period
     )
-    df_drop_missing = preprocess_lcl.filter_missing_kwh(df_drop_dupes)
 
     def test_week(self):
         expected_week = pd.to_datetime(
@@ -70,20 +73,22 @@ class TestPreprocessLCL:
         ).all()
 
     def test_drop_dupes_and_replace_nulls(self):
-        assert len(self.df_drop_dupes) == 7
-        assert self.df_drop_dupes["kwh"].sum() == 2.1
+        assert len(self.df_drop_dupes) == 6
+        assert self.df_drop_dupes["kwh"].sum() == pytest.approx(2.3)
 
     def test_filter_missing_kwh(self):
         # test_df is filled with only 1 kwh per date reading
         # filter_missing_kwh checks that each date has 48 readings
         # and drop dates with < 48 readings
-        assert len(self.df_drop_missing) == 0
+        with pytest.raises(AssertionError):
+            _ = preprocess_lcl.filter_missing_kwh(self.df_drop_dupes)
 
     def test_pack_smart_meter_data_into_arrays(self):
         df_packed = preprocess_lcl.pack_smart_meter_data_into_arrays(
-            self.df_drop_dupes
+            self.df_drop_dupes,
+            feature_cols=["stdorToU"],
         )
-        assert len(df_packed) == 4
-        assert df_packed.query("LCLid=='MAC000002' and month==1 and day==15")[
+        assert len(df_packed) == 3
+        assert df_packed.query("ID=='MAC000002' and month==1 and day==15")[
             "kwh"
-        ].values.tolist()[0] == [0.0, 0.4, 0.5, 0.6]
+        ].values.tolist()[0] == [0.4, 0.4, 0.5, 0.6]

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -2,11 +2,11 @@ import numpy as np
 import pytest
 
 from opensynth.datasets.datasets_utils import NoiseFactory, NoiseType
-from tests.utils import df_test
+from tests.utils import df_test_half_hourly
 
 
 class TestNoiseFactory:
-    df_test = df_test()
+    df_test = df_test_half_hourly()
 
     @pytest.mark.parametrize(
         "noise_type",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,7 @@ def df_test() -> pd.DataFrame:
         "2013-01-15 03:00:00",
         "2013-01-15 03:30:00",
     ]
-    kwh = [0.1, 0.2, 0.3, 0.3, "Null", 0.4, 0.5, 0.6]
+    kwh = [0.1, "Null", 0.3, 0.3, 0.4, 0.4, 0.5, 0.6]
     tariff = ["A", "A", "A", "A", "A", "A", "A", "A"]
     df = pd.DataFrame(
         {"LCLid": lcl_id, "DateTime": dt, "kwh": kwh, "stdorToU": tariff}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,10 @@
+from datetime import datetime, timedelta
+
+import numpy as np
 import pandas as pd
 
 
-def df_test() -> pd.DataFrame:
+def df_test_half_hourly() -> pd.DataFrame:
     """
     Test Dataframe
 
@@ -30,6 +33,31 @@ def df_test() -> pd.DataFrame:
     ]
     kwh = [0.1, "Null", 0.3, 0.3, 0.4, 0.4, 0.5, 0.6]
     tariff = ["A", "A", "A", "A", "A", "A", "A", "A"]
+    df = pd.DataFrame(
+        {"LCLid": lcl_id, "DateTime": dt, "kwh": kwh, "stdorToU": tariff}
+    )
+    return df
+
+
+def df_test_hourly() -> pd.DataFrame:
+    """
+    Test Dataframe
+
+    Returns:
+        pd.DataFrame: Test Dataframe
+    """
+    lcl_id = ["MAC000002"] * 48
+
+    # start time
+    start = datetime(2013, 1, 3, 0, 0, 0)
+    # generate 48 timestamps, 1 hour apart
+    dt = [
+        (start + timedelta(hours=i)).strftime("%Y-%m-%d %H:%M:%S")
+        for i in range(48)
+    ]
+
+    kwh = np.random.rand(48).round(2).tolist()
+    tariff = ["A"] * 48
     df = pd.DataFrame(
         {"LCLid": lcl_id, "DateTime": dt, "kwh": kwh, "stdorToU": tariff}
     )


### PR DESCRIPTION
1. Allow for half-hourly and hourly resolution input data 
2. Remove LCL-specific hard-coded columns and values from pre-processing scripts
4. Add more detailed documentation to preprocessing scripts  
5. Allow user to choose input arguments to run preprocessing on their own datasets
6. Drop rows with nan values by default, but option to replace nulls with zeros. 